### PR TITLE
Add static assets support with configurable output modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,15 @@ my-blog/
 │   ├── Navbar.html
 │   ├── Footer.html
 │   └── Alert.html
+├── static/             # Optional static assets copied on build
+│   ├── favicon.ico
+│   └── styles.css
 ├── output/             # Generated site
 │   ├── index.html
 │   ├── about.html
+│   ├── static/
+│   │   ├── favicon.ico
+│   │   └── styles.css
 │   ├── syntax.css
 │   └── feed.xml
 ├── py-ssg.toml         # Configuration
@@ -127,6 +133,8 @@ name = "Blog Name"
 url = "https://yourblog.dev"
 description = "My blog"
 cache = true                    # Enable incremental build caching
+static_dir = "static"           # Source directory for copied assets
+static_dir_output = "static"    # "static" -> output/static, "root" -> output/
 
 [py-ssg.server]
 port = 8000                     # Dev server port
@@ -158,6 +166,18 @@ tags = ["tech"]
 ```
 
 All configuration is accessible in templates via the `{{ site }}` variable (e.g., `{{ site.name }}`, `{{ site.url }}`).
+
+## Static Assets
+
+If your project has a `static/` directory, py-ssg copies it on every build after template rendering.
+
+- `static_dir = "static"` copies `static/` to `output/static/`
+- `static_dir_output = "root"` merges the directory directly into `output/`. Because static assets are copied after rendering, files in `static/` with the same relative path as generated output files overwrite the generated files.
+- Set `static_dir` to another directory name, such as `public`, if you prefer a different source path
+
+With the default layout, reference assets from templates with paths like `/static/styles.css` or `/static/favicon.ico`.
+
+When using `static_dir_output = "root"`, avoid filename collisions with generated pages and assets such as `index.html`, `feed.xml`, and `syntax.css` unless you intentionally want the static file to take precedence.
 
 ## Markdown Content
 
@@ -408,7 +428,7 @@ def before_component_parsing(context):
 def after_build(context):
     """After the full build completes.
 
-    Good for post-processing, sitemaps, copying static assets.
+    Good for post-processing and sitemaps.
     """
     pass
 ```

--- a/pyssg/commands/build.py
+++ b/pyssg/commands/build.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 import time
+from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 from pyssg.commands.base_command import BaseCommand
@@ -31,57 +33,153 @@ def _discover_components(components_dir: Path) -> list[str]:
     return names
 
 
+class ProjectDirectory(StrEnum):
+    CONTENT = "content"
+    TEMPLATES = "templates"
+    COMPONENTS = "components"
+    OUTPUT = "output"
+    STATIC = "static"
+
+
+class StaticDirOutputMode(StrEnum):
+    STATIC = "static"
+    ROOT = "root"
+
+    def destination(self, output_dir: Path) -> Path:
+        output_dir = Path(output_dir)
+        if self is StaticDirOutputMode.ROOT:
+            return output_dir
+        return output_dir / self.value
+
+    @property
+    def output_path(self) -> str:
+        if self is StaticDirOutputMode.ROOT:
+            return "output/"
+        return f"output/{self.value}/"
+
+
+def _copy_static_assets(
+    static_dir: Path, output_dir: Path, output_mode: str
+) -> str | None:
+    if not os.path.isdir(static_dir):
+        return None
+
+    mode = StaticDirOutputMode(output_mode)
+    dest = mode.destination(output_dir)
+    shutil.copytree(static_dir, dest, dirs_exist_ok=os.path.exists(dest))
+    return mode.output_path
+
+
+@dataclass
+class BuildPaths:
+    project_dir: Path
+    templates_dir: Path
+    components_dir: Path
+    output_dir: Path
+
+
+@dataclass
+class RenderSummary:
+    total_files: int
+    built_files: int
+    cached_files: int
+    component_names: list[str]
+    rendering_time: float
+
+
 class BuildCommand(BaseCommand):
     def execute(self) -> None:
         start_time = time.perf_counter()
-
-        project_dir = Path.cwd()
-        templates_dir = project_dir / "templates"
-        components_dir = project_dir / "components"
-        output_dir = project_dir / "output"
-
-        config = SiteConfig.load(project_dir)
-
-        cache = BuildCache(cache_dir=project_dir, enabled=config.cache)
+        paths = self._build_paths()
+        config = SiteConfig.load(paths.project_dir)
+        cache = BuildCache(cache_dir=paths.project_dir, enabled=config.cache)
         cache.load()
-
-        build_script = BuildScript(project_dir)
+        build_script = BuildScript(paths.project_dir)
         context = BuildContext(
             config=config,
             cache=cache,
-            project_dir=project_dir,
-            templates_dir=templates_dir,
-            components_dir=components_dir,
-            output_dir=output_dir,
+            project_dir=paths.project_dir,
+            templates_dir=paths.templates_dir,
+            components_dir=paths.components_dir,
+            output_dir=paths.output_dir,
         )
 
         build_script.before_build(context)
-
-        highlighter = None
-        render_markdown = None
-        if config.syntax.enabled:
-            highlighter = SyntaxHighlighter(
-                theme_light=config.syntax.theme_light,
-                theme_dark=config.syntax.theme_dark,
-            )
-            render_markdown = highlighter.render_markdown
-
-        toc_generator = None
-        if config.toc.enabled:
-            toc_generator = TocGenerator(max_depth=config.toc.max_depth)
+        highlighter = self._create_highlighter(config)
+        render_markdown = highlighter.render_markdown if highlighter else None
+        toc_generator = self._create_toc_generator(config)
 
         build_script.before_markdown_parsing(context)
-
-        self._info("Parsing markdown files...")
-        parsing_start = time.perf_counter()
-        parser = MarkdownParser(
-            content_dir=project_dir / "content",
+        collection, parsing_time = self._parse_markdown(
+            paths=paths,
+            config=config,
             render_markdown=render_markdown,
             toc_generator=toc_generator,
         )
-        workers = os.cpu_count() or 1
+        context.content = collection
+
+        build_script.before_component_parsing(context)
+        render_summary = self._render_templates(
+            paths=paths,
+            config=config,
+            cache=cache,
+            collection=collection,
+            highlighter=highlighter,
+        )
+        feed_count = self._generate_feeds(
+            config=config,
+            output_dir=paths.output_dir,
+            collection=collection,
+        )
+
+        cache.save()
+        build_script.after_build(context)
+        total_time = time.perf_counter() - start_time
+        self._print_summary(
+            render_summary=render_summary,
+            feed_count=feed_count,
+            parsing_time=parsing_time,
+            total_time=total_time,
+        )
+
+    def _build_paths(self) -> BuildPaths:
+        project_dir = Path.cwd()
+        return BuildPaths(
+            project_dir=project_dir,
+            templates_dir=project_dir / ProjectDirectory.TEMPLATES,
+            components_dir=project_dir / ProjectDirectory.COMPONENTS,
+            output_dir=project_dir / ProjectDirectory.OUTPUT,
+        )
+
+    def _create_highlighter(self, config: SiteConfig) -> SyntaxHighlighter | None:
+        if not config.syntax.enabled:
+            return None
+        return SyntaxHighlighter(
+            theme_light=config.syntax.theme_light,
+            theme_dark=config.syntax.theme_dark,
+        )
+
+    def _create_toc_generator(self, config: SiteConfig) -> TocGenerator | None:
+        if not config.toc.enabled:
+            return None
+        return TocGenerator(max_depth=config.toc.max_depth)
+
+    def _parse_markdown(
+        self,
+        paths: BuildPaths,
+        config: SiteConfig,
+        render_markdown,
+        toc_generator: TocGenerator | None,
+    ):
+        self._info("Parsing markdown files...")
+        parsing_start = time.perf_counter()
+        parser = MarkdownParser(
+            content_dir=paths.project_dir / ProjectDirectory.CONTENT,
+            render_markdown=render_markdown,
+            toc_generator=toc_generator,
+        )
         collection = parser.parse(
-            workers=workers,
+            workers=os.cpu_count() or 1,
             syntax_config={
                 "enabled": config.syntax.enabled,
                 "theme_light": config.syntax.theme_light,
@@ -92,90 +190,142 @@ class BuildCommand(BaseCommand):
                 "max_depth": config.toc.max_depth,
             },
         )
-        parsing_time = time.perf_counter() - parsing_start
+        return collection, time.perf_counter() - parsing_start
 
-        context.content = collection
-
-        build_script.before_component_parsing(context)
-
+    def _render_templates(
+        self,
+        paths: BuildPaths,
+        config: SiteConfig,
+        cache: BuildCache,
+        collection,
+        highlighter: SyntaxHighlighter | None,
+    ) -> RenderSummary:
         self._info("Rendering templates...")
         rendering_start = time.perf_counter()
-        component_names = _discover_components(components_dir)
+        component_names = _discover_components(paths.components_dir)
         engine = HtmlTemplateEngine(
-            templates_dir=templates_dir,
-            components_dir=components_dir,
+            templates_dir=paths.templates_dir,
+            components_dir=paths.components_dir,
             component_names=component_names,
             config=config,
         )
-        os.makedirs(output_dir, exist_ok=True)
+        os.makedirs(paths.output_dir, exist_ok=True)
 
+        self._copy_template_directories(paths)
+        total_files, built_files, cached_files = self._render_template_files(
+            templates_dir=paths.templates_dir,
+            output_dir=paths.output_dir,
+            engine=engine,
+            collection=collection,
+            cache=cache,
+        )
+        self._write_syntax_stylesheet(
+            output_dir=paths.output_dir, highlighter=highlighter
+        )
+        self._copy_static_assets(paths=paths, config=config)
+
+        return RenderSummary(
+            total_files=total_files,
+            built_files=built_files,
+            cached_files=cached_files,
+            component_names=component_names,
+            rendering_time=time.perf_counter() - rendering_start,
+        )
+
+    def _copy_template_directories(self, paths: BuildPaths) -> None:
+        for entry in os.listdir(paths.templates_dir):
+            entry_path = os.path.join(paths.templates_dir, entry)
+            if not os.path.isdir(entry_path):
+                continue
+            dest = os.path.join(paths.output_dir, entry)
+            if os.path.exists(dest):
+                shutil.rmtree(dest)
+            shutil.copytree(entry_path, dest)
+
+    def _render_template_files(
+        self,
+        templates_dir: Path,
+        output_dir: Path,
+        engine: HtmlTemplateEngine,
+        collection,
+        cache: BuildCache,
+    ) -> tuple[int, int, int]:
         total_files = 0
         built_files = 0
         cached_files = 0
 
-        for entry in os.listdir(templates_dir):
-            entry_path = os.path.join(templates_dir, entry)
-            if os.path.isdir(entry_path):
-                dest = os.path.join(output_dir, entry)
-                if os.path.exists(dest):
-                    shutil.rmtree(dest)
-                shutil.copytree(entry_path, dest)
-                continue
-
         for filename in os.listdir(templates_dir):
             if not filename.endswith(".html"):
                 continue
+
             total_files += 1
             filepath = os.path.join(templates_dir, filename)
             with open(filepath) as f:
                 template = f.read()
 
             is_dynamic = cache.has_dynamic_constructs(template)
-
             if not is_dynamic and not cache.needs_rebuild(filename, template):
                 cached_files += 1
                 continue
 
             rendered = engine.render(template, context={"content": list(collection)})
-
             output_path = os.path.join(output_dir, filename)
             with open(output_path, "w") as f:
                 f.write(rendered)
 
             if not is_dynamic:
                 cache.update(filename, template)
-
             built_files += 1
 
-        if highlighter:
-            css_path = os.path.join(output_dir, "syntax.css")
-            with open(css_path, "w") as f:
-                f.write(highlighter.get_stylesheet())
+        return total_files, built_files, cached_files
 
-        rendering_time = time.perf_counter() - rendering_start
+    def _write_syntax_stylesheet(
+        self,
+        output_dir: Path,
+        highlighter: SyntaxHighlighter | None,
+    ) -> None:
+        if not highlighter:
+            return
+        css_path = os.path.join(output_dir, "syntax.css")
+        with open(css_path, "w") as f:
+            f.write(highlighter.get_stylesheet())
 
+    def _copy_static_assets(self, paths: BuildPaths, config: SiteConfig) -> None:
+        static_output = _copy_static_assets(
+            static_dir=paths.project_dir / config.static_dir,
+            output_dir=paths.output_dir,
+            output_mode=config.static_dir_output,
+        )
+        if static_output:
+            self._info(f"Copied static assets -> {static_output}")
+
+    def _generate_feeds(self, config: SiteConfig, output_dir: Path, collection) -> int:
+        if not config.feeds:
+            return 0
+
+        self._info("Generating RSS feeds...")
+        generator = RssFeedGenerator(config=config)
         feed_count = 0
-        if config.feeds:
-            self._info("Generating RSS feeds...")
-            generator = RssFeedGenerator(config=config)
-            for output_name, xml in generator.generate(collection):
-                output_path = os.path.join(output_dir, output_name)
-                with open(output_path, "w") as f:
-                    f.write(xml)
-                feed_count += 1
+        for output_name, xml in generator.generate(collection):
+            output_path = os.path.join(output_dir, output_name)
+            with open(output_path, "w") as f:
+                f.write(xml)
+            feed_count += 1
+        return feed_count
 
-        cache.save()
-
-        build_script.after_build(context)
-
-        total_time = time.perf_counter() - start_time
-
+    def _print_summary(
+        self,
+        render_summary: RenderSummary,
+        feed_count: int,
+        parsing_time: float,
+        total_time: float,
+    ) -> None:
         self._success("Build complete!")
-        self._success(f"Total files: {total_files}")
-        self._success(f"Total components: {len(component_names)}")
-        self._success(f"Built: {built_files}")
-        self._success(f"Cached: {cached_files}")
+        self._success(f"Total files: {render_summary.total_files}")
+        self._success(f"Total components: {len(render_summary.component_names)}")
+        self._success(f"Built: {render_summary.built_files}")
+        self._success(f"Cached: {render_summary.cached_files}")
         self._success(f"RSS feeds: {feed_count}")
         self._success(f"Parsing time: {parsing_time:.3f}s")
-        self._success(f"Rendering time: {rendering_time:.3f}s")
+        self._success(f"Rendering time: {render_summary.rendering_time:.3f}s")
         self._success(f"Total time: {total_time:.3f}s")

--- a/pyssg/commands/serve.py
+++ b/pyssg/commands/serve.py
@@ -2,7 +2,7 @@ import time
 from pathlib import Path
 
 from pyssg.commands.base_command import BaseCommand
-from pyssg.commands.build import BuildCommand
+from pyssg.commands.build import BuildCommand, ProjectDirectory
 from pyssg.modules.config import SiteConfig
 from pyssg.modules.server import Server
 from pyssg.modules.watcher import Watcher
@@ -21,16 +21,21 @@ class ServeCommand(BaseCommand):
         self._info("Running initial build...")
         self._rebuild()
 
-        server = Server(directory=project_dir / "output", port=port)
+        server = Server(directory=project_dir / ProjectDirectory.OUTPUT, port=port)
         server.start()
         self._success(f"Serving on http://localhost:{port}")
 
+        directories = [
+            project_dir / ProjectDirectory.CONTENT,
+            project_dir / ProjectDirectory.TEMPLATES,
+            project_dir / ProjectDirectory.COMPONENTS,
+        ]
+        static_dir = project_dir / config.static_dir
+        if static_dir.exists():
+            directories.append(static_dir)
+
         watcher = Watcher(
-            directories=[
-                project_dir / "content",
-                project_dir / "templates",
-                project_dir / "components",
-            ],
+            directories=directories,
             on_change=self._rebuild,
         )
         watcher.start()

--- a/pyssg/modules/config.py
+++ b/pyssg/modules/config.py
@@ -3,6 +3,18 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 CONFIG_FILENAME = "py-ssg.toml"
+STATIC_DIR_OUTPUT_MODES = ("static", "root")
+
+
+def _validate_static_dir_output(output_mode: str) -> str:
+    if output_mode in STATIC_DIR_OUTPUT_MODES:
+        return output_mode
+
+    supported_modes = '", "'.join(STATIC_DIR_OUTPUT_MODES)
+    raise ValueError(
+        f'Invalid static_dir_output value: "{output_mode}". '
+        f'Supported modes: "{supported_modes}".'
+    )
 
 
 @dataclass
@@ -82,6 +94,8 @@ class SiteConfig:
     name: str = ""
     url: str = ""
     description: str = ""
+    static_dir: str = "static"
+    static_dir_output: str = "static"
     authors: list[AuthorConfig] = field(default_factory=list)
     feeds: list[FeedConfig] = field(default_factory=list)
     cache: bool = True
@@ -105,10 +119,15 @@ class SiteConfig:
         syntax = SyntaxConfig.from_dict(data.get("syntax", {}))
         server = ServerConfig.from_dict(data.get("server", {}))
         toc = TocConfig.from_dict(data.get("toc", {}))
+        static_dir_output = _validate_static_dir_output(
+            str(data.get("static_dir_output", "static"))
+        )
         return cls(
             name=str(data.get("name", "")),
             url=str(data.get("url", "")),
             description=str(data.get("description", "")),
+            static_dir=str(data.get("static_dir", "static")),
+            static_dir_output=static_dir_output,
             authors=authors,
             feeds=feeds,
             cache=bool(data.get("cache", True)),

--- a/pyssg/templates/py-ssg.toml
+++ b/pyssg/templates/py-ssg.toml
@@ -3,6 +3,8 @@ name = "Blog Name"
 url = "https://yourblog.dev"
 description = "My blog"
 cache = true
+static_dir = "static"
+static_dir_output = "static"
 
 [py-ssg.server]
 port = 8000

--- a/tests/app/commands/test_build.py
+++ b/tests/app/commands/test_build.py
@@ -1,8 +1,9 @@
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
-from pyssg.commands.build import BuildCommand
+from pyssg.commands.build import BuildCommand, BuildPaths
 from pyssg.modules.build_script import BuildContext
-from pyssg.modules.config import SiteConfig, SyntaxConfig, TocConfig
+from pyssg.modules.config import FeedConfig, SiteConfig, SyntaxConfig, TocConfig
 from pyssg.modules.markdown import MarkdownCollection, MarkdownContent
 
 TEST_POST = MarkdownContent(filename="post.md", html="<p>Hi</p>", title="Post")
@@ -17,6 +18,8 @@ def _default_config(**overrides):
         name=overrides.get("name", ""),
         url=overrides.get("url", ""),
         description=overrides.get("description", ""),
+        static_dir=overrides.get("static_dir", "static"),
+        static_dir_output=overrides.get("static_dir_output", "static"),
         cache=overrides.get("cache", True),
         syntax=syntax,
         toc=toc,
@@ -32,6 +35,7 @@ def _setup_path_and_os(
     component_subdirs=None,
 ):
     """Common setup for path and os mocks."""
+    mock_path.side_effect = Path
     mock_path.cwd.return_value.__truediv__ = lambda self, x: f"/project/{x}"
     template_files = template_files or []
     component_files = component_files or []
@@ -451,6 +455,198 @@ class TestExecute:
             command.execute()
 
         mock_shutil.copytree.assert_not_called()
+
+    @patch(f"{TEST_PATH}.BuildScript")
+    @patch(f"{TEST_PATH}.shutil")
+    @patch(f"{TEST_PATH}.SiteConfig")
+    @patch(f"{TEST_PATH}.BuildCache")
+    @patch(f"{TEST_PATH}.open", new_callable=mock_open, read_data="<h1>Template</h1>")
+    @patch(f"{TEST_PATH}.os")
+    @patch(f"{TEST_PATH}.HtmlTemplateEngine")
+    @patch(f"{TEST_PATH}.MarkdownParser")
+    @patch(f"{TEST_PATH}.Path")
+    def test_copies_static_directory_to_output_static(
+        self,
+        mock_path,
+        mock_parser_cls,
+        mock_engine_cls,
+        mock_os,
+        mock_file,
+        mock_cache_cls,
+        mock_config_cls,
+        mock_shutil,
+        mock_script_cls,
+    ):
+        _setup_path_and_os(mock_path, mock_os, template_files=["index.html"])
+        _setup_cache(mock_cache_cls)
+        mock_config_cls.load.return_value = _default_config()
+        mock_parser_cls.return_value.parse.return_value = MarkdownCollection()
+        mock_engine_cls.return_value.render.return_value = "<h1>Rendered</h1>"
+        mock_os.path.isdir.side_effect = lambda path: str(path) == "/project/static"
+        command = BuildCommand()
+
+        with patch.object(command, "_info"), patch.object(command, "_success"):
+            command.execute()
+
+        assert mock_shutil.copytree.call_args_list[-1].args == (
+            "/project/static",
+            Path("/project/output/static"),
+        )
+        assert mock_shutil.copytree.call_args_list[-1].kwargs == {
+            "dirs_exist_ok": False
+        }
+
+    @patch(f"{TEST_PATH}.BuildScript")
+    @patch(f"{TEST_PATH}.shutil")
+    @patch(f"{TEST_PATH}.SiteConfig")
+    @patch(f"{TEST_PATH}.BuildCache")
+    @patch(f"{TEST_PATH}.open", new_callable=mock_open, read_data="<h1>Template</h1>")
+    @patch(f"{TEST_PATH}.os")
+    @patch(f"{TEST_PATH}.HtmlTemplateEngine")
+    @patch(f"{TEST_PATH}.MarkdownParser")
+    @patch(f"{TEST_PATH}.Path")
+    def test_allows_existing_output_static_when_copying(
+        self,
+        mock_path,
+        mock_parser_cls,
+        mock_engine_cls,
+        mock_os,
+        mock_file,
+        mock_cache_cls,
+        mock_config_cls,
+        mock_shutil,
+        mock_script_cls,
+    ):
+        _setup_path_and_os(mock_path, mock_os, template_files=["index.html"])
+        _setup_cache(mock_cache_cls)
+        mock_config_cls.load.return_value = _default_config()
+        mock_parser_cls.return_value.parse.return_value = MarkdownCollection()
+        mock_engine_cls.return_value.render.return_value = "<h1>Rendered</h1>"
+        mock_os.path.isdir.side_effect = lambda path: str(path) == "/project/static"
+        mock_os.path.exists.side_effect = lambda path: (
+            str(path) == "/project/output/static"
+        )
+        command = BuildCommand()
+
+        with patch.object(command, "_info"), patch.object(command, "_success"):
+            command.execute()
+
+        mock_shutil.rmtree.assert_not_called()
+        assert mock_shutil.copytree.call_args_list[-1].args == (
+            "/project/static",
+            Path("/project/output/static"),
+        )
+        assert mock_shutil.copytree.call_args_list[-1].kwargs == {"dirs_exist_ok": True}
+
+    @patch(f"{TEST_PATH}.BuildScript")
+    @patch(f"{TEST_PATH}.shutil")
+    @patch(f"{TEST_PATH}.SiteConfig")
+    @patch(f"{TEST_PATH}.BuildCache")
+    @patch(f"{TEST_PATH}.open", new_callable=mock_open, read_data="<h1>Template</h1>")
+    @patch(f"{TEST_PATH}.os")
+    @patch(f"{TEST_PATH}.HtmlTemplateEngine")
+    @patch(f"{TEST_PATH}.MarkdownParser")
+    @patch(f"{TEST_PATH}.Path")
+    def test_copies_static_directory_to_output_root_when_configured(
+        self,
+        mock_path,
+        mock_parser_cls,
+        mock_engine_cls,
+        mock_os,
+        mock_file,
+        mock_cache_cls,
+        mock_config_cls,
+        mock_shutil,
+        mock_script_cls,
+    ):
+        _setup_path_and_os(mock_path, mock_os, template_files=["index.html"])
+        _setup_cache(mock_cache_cls)
+        mock_config_cls.load.return_value = _default_config(static_dir_output="root")
+        mock_parser_cls.return_value.parse.return_value = MarkdownCollection()
+        mock_engine_cls.return_value.render.return_value = "<h1>Rendered</h1>"
+        mock_os.path.isdir.side_effect = lambda path: str(path) == "/project/static"
+        command = BuildCommand()
+
+        with patch.object(command, "_info"), patch.object(command, "_success"):
+            command.execute()
+
+        mock_shutil.copytree.assert_called_once_with(
+            "/project/static", Path("/project/output"), dirs_exist_ok=False
+        )
+
+    @patch(f"{TEST_PATH}.BuildScript")
+    @patch(f"{TEST_PATH}.shutil")
+    @patch(f"{TEST_PATH}.SiteConfig")
+    @patch(f"{TEST_PATH}.BuildCache")
+    @patch(f"{TEST_PATH}.open", new_callable=mock_open, read_data="<h1>Template</h1>")
+    @patch(f"{TEST_PATH}.os")
+    @patch(f"{TEST_PATH}.HtmlTemplateEngine")
+    @patch(f"{TEST_PATH}.MarkdownParser")
+    @patch(f"{TEST_PATH}.Path")
+    def test_allows_existing_output_root_when_copying(
+        self,
+        mock_path,
+        mock_parser_cls,
+        mock_engine_cls,
+        mock_os,
+        mock_file,
+        mock_cache_cls,
+        mock_config_cls,
+        mock_shutil,
+        mock_script_cls,
+    ):
+        _setup_path_and_os(mock_path, mock_os, template_files=["index.html"])
+        _setup_cache(mock_cache_cls)
+        mock_config_cls.load.return_value = _default_config(static_dir_output="root")
+        mock_parser_cls.return_value.parse.return_value = MarkdownCollection()
+        mock_engine_cls.return_value.render.return_value = "<h1>Rendered</h1>"
+        mock_os.path.isdir.side_effect = lambda path: str(path) == "/project/static"
+        mock_os.path.exists.side_effect = lambda path: str(path) == "/project/output"
+        command = BuildCommand()
+
+        with patch.object(command, "_info"), patch.object(command, "_success"):
+            command.execute()
+
+        mock_shutil.copytree.assert_called_once_with(
+            "/project/static", Path("/project/output"), dirs_exist_ok=True
+        )
+
+    @patch(f"{TEST_PATH}.BuildScript")
+    @patch(f"{TEST_PATH}.shutil")
+    @patch(f"{TEST_PATH}.SiteConfig")
+    @patch(f"{TEST_PATH}.BuildCache")
+    @patch(f"{TEST_PATH}.open", new_callable=mock_open, read_data="<h1>Template</h1>")
+    @patch(f"{TEST_PATH}.os")
+    @patch(f"{TEST_PATH}.HtmlTemplateEngine")
+    @patch(f"{TEST_PATH}.MarkdownParser")
+    @patch(f"{TEST_PATH}.Path")
+    def test_outputs_info_message_when_static_assets_are_copied(
+        self,
+        mock_path,
+        mock_parser_cls,
+        mock_engine_cls,
+        mock_os,
+        mock_file,
+        mock_cache_cls,
+        mock_config_cls,
+        mock_shutil,
+        mock_script_cls,
+    ):
+        _setup_path_and_os(mock_path, mock_os, template_files=["index.html"])
+        _setup_cache(mock_cache_cls)
+        mock_config_cls.load.return_value = _default_config()
+        mock_parser_cls.return_value.parse.return_value = MarkdownCollection()
+        mock_engine_cls.return_value.render.return_value = "<h1>Rendered</h1>"
+        mock_os.path.isdir.side_effect = lambda path: str(path) == "/project/static"
+        command = BuildCommand()
+
+        with (
+            patch.object(command, "_info") as mock_info,
+            patch.object(command, "_success"),
+        ):
+            command.execute()
+
+        mock_info.assert_any_call("Copied static assets -> output/static/")
 
     @patch(f"{TEST_PATH}.BuildScript")
     @patch(f"{TEST_PATH}.time")
@@ -1554,3 +1750,120 @@ class TestBuildScript:
             command.execute()
 
         assert captured_content["content"] is None
+
+
+class TestHelpers:
+    @patch(f"{TEST_PATH}.Path")
+    def test_build_paths_uses_project_directories(self, mock_path):
+        mock_project_dir = Path("/project")
+        mock_path.cwd.return_value = mock_project_dir
+        command = BuildCommand()
+
+        paths = command._build_paths()
+
+        assert paths == BuildPaths(
+            project_dir=mock_project_dir,
+            templates_dir=Path("/project/templates"),
+            components_dir=Path("/project/components"),
+            output_dir=Path("/project/output"),
+        )
+
+    @patch(f"{TEST_PATH}.SyntaxHighlighter")
+    def test_create_highlighter_returns_instance_when_enabled(
+        self, mock_highlighter_cls
+    ):
+        config = _default_config(
+            syntax=SyntaxConfig(enabled=True, theme_light="tango", theme_dark="dracula")
+        )
+        command = BuildCommand()
+
+        highlighter = command._create_highlighter(config)
+
+        assert highlighter is mock_highlighter_cls.return_value
+        mock_highlighter_cls.assert_called_once_with(
+            theme_light="tango",
+            theme_dark="dracula",
+        )
+
+    def test_create_highlighter_returns_none_when_disabled(self):
+        command = BuildCommand()
+
+        highlighter = command._create_highlighter(
+            _default_config(syntax=SyntaxConfig(enabled=False))
+        )
+
+        assert highlighter is None
+
+    @patch(f"{TEST_PATH}.TocGenerator")
+    def test_create_toc_generator_returns_instance_when_enabled(self, mock_toc_cls):
+        config = _default_config(toc=TocConfig(enabled=True, max_depth=4))
+        command = BuildCommand()
+
+        toc_generator = command._create_toc_generator(config)
+
+        assert toc_generator is mock_toc_cls.return_value
+        mock_toc_cls.assert_called_once_with(max_depth=4)
+
+    def test_create_toc_generator_returns_none_when_disabled(self):
+        command = BuildCommand()
+
+        toc_generator = command._create_toc_generator(
+            _default_config(toc=TocConfig(enabled=False))
+        )
+
+        assert toc_generator is None
+
+    @patch(f"{TEST_PATH}.open", new_callable=mock_open)
+    @patch(f"{TEST_PATH}.RssFeedGenerator")
+    def test_generate_feeds_writes_each_feed_and_returns_count(
+        self,
+        mock_generator_cls,
+        mock_file,
+    ):
+        config = _default_config()
+        config.feeds = [FeedConfig(title="Main"), FeedConfig(title="News")]
+        collection = MarkdownCollection()
+        collection.add(TEST_POST)
+        mock_generator_cls.return_value.generate.return_value = [
+            ("feed.xml", "<rss />"),
+            ("news.xml", "<rss />"),
+        ]
+        command = BuildCommand()
+
+        with patch.object(command, "_info") as mock_info:
+            feed_count = command._generate_feeds(
+                config=config,
+                output_dir=Path("/project/output"),
+                collection=collection,
+            )
+
+        assert feed_count == 2
+        mock_info.assert_called_once_with("Generating RSS feeds...")
+        mock_generator_cls.assert_called_once_with(config=config)
+        assert [call.args for call in mock_file.call_args_list] == [
+            ("/project/output/feed.xml", "w"),
+            ("/project/output/news.xml", "w"),
+        ]
+
+    @patch(f"{TEST_PATH}.open", new_callable=mock_open)
+    @patch(f"{TEST_PATH}.RssFeedGenerator")
+    def test_generate_feeds_skips_generator_when_no_feeds_configured(
+        self,
+        mock_generator_cls,
+        mock_file,
+    ):
+        config = _default_config()
+        config.feeds = []
+        command = BuildCommand()
+
+        with patch.object(command, "_info") as mock_info:
+            feed_count = command._generate_feeds(
+                config=config,
+                output_dir=Path("/project/output"),
+                collection=MarkdownCollection(),
+            )
+
+        assert feed_count == 0
+        mock_info.assert_not_called()
+        mock_generator_cls.assert_not_called()
+        mock_file.assert_not_called()

--- a/tests/app/commands/test_serve.py
+++ b/tests/app/commands/test_serve.py
@@ -9,6 +9,7 @@ TEST_PATH = "pyssg.commands.serve"
 
 def _default_config(**overrides):
     return SiteConfig(
+        static_dir=overrides.get("static_dir", "static"),
         server=overrides.get("server", ServerConfig()),
     )
 
@@ -140,6 +141,36 @@ class TestExecute:
         assert Path("/project/templates") in directories
         assert Path("/project/components") in directories
         mock_watcher.start.assert_called_once()
+
+    @patch(f"{TEST_PATH}.SiteConfig")
+    @patch(f"{TEST_PATH}.Watcher")
+    @patch(f"{TEST_PATH}.Server")
+    @patch(f"{TEST_PATH}.BuildCommand")
+    @patch(f"{TEST_PATH}.Path")
+    def test_starts_watcher_on_static_directory_when_present(
+        self,
+        mock_path,
+        mock_build_cls,
+        mock_server_cls,
+        mock_watcher_cls,
+        mock_config_cls,
+    ):
+        mock_path.cwd.return_value = Path("/project")
+        mock_config_cls.load.return_value = _default_config(static_dir="public")
+        mock_server = MagicMock()
+        mock_server_cls.return_value = mock_server
+        mock_watcher = MagicMock()
+        mock_watcher_cls.return_value = mock_watcher
+        command = ServeCommand(port=8000)
+
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch.object(command, "_wait_forever", side_effect=KeyboardInterrupt),
+        ):
+            command.execute()
+
+        directories = mock_watcher_cls.call_args.kwargs["directories"]
+        assert Path("/project/public") in directories
 
     @patch(f"{TEST_PATH}.SiteConfig")
     @patch(f"{TEST_PATH}.Watcher")

--- a/tests/app/modules/test_config.py
+++ b/tests/app/modules/test_config.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
+import pytest
+
 from pyssg.modules.config import (
     AuthorConfig,
     FeedConfig,
@@ -105,6 +107,8 @@ class TestSiteConfig:
         assert config.name == ""
         assert config.url == ""
         assert config.description == ""
+        assert config.static_dir == "static"
+        assert config.static_dir_output == "static"
         assert config.authors == []
         assert config.feeds == []
         assert config.cache is True
@@ -116,6 +120,8 @@ class TestSiteConfig:
             "name": "My Blog",
             "url": "https://example.com",
             "description": "A blog",
+            "static_dir": "public",
+            "static_dir_output": "root",
             "cache": False,
             "authors": [{"name": "Jane", "email": "jane@example.com"}],
             "feeds": [{"title": "Feed", "output": "feed.xml"}],
@@ -126,6 +132,8 @@ class TestSiteConfig:
         assert config.name == "My Blog"
         assert config.url == "https://example.com"
         assert config.description == "A blog"
+        assert config.static_dir == "public"
+        assert config.static_dir_output == "root"
         assert config.cache is False
         assert len(config.authors) == 1
         assert config.authors[0].name == "Jane"
@@ -139,11 +147,20 @@ class TestSiteConfig:
         assert config.name == ""
         assert config.url == ""
         assert config.description == ""
+        assert config.static_dir == "static"
+        assert config.static_dir_output == "static"
         assert config.authors == []
         assert config.feeds == []
         assert config.cache is True
         assert config.syntax == SyntaxConfig()
         assert config.server == ServerConfig()
+
+    def test_from_dict_raises_for_invalid_static_dir_output(self):
+        with pytest.raises(
+            ValueError,
+            match='Invalid static_dir_output value: "invalid". Supported modes: "static", "root".',
+        ):
+            SiteConfig.from_dict({"static_dir_output": "invalid"})
 
     def test_from_dict_syntax_section(self):
         config = SiteConfig.from_dict(
@@ -219,14 +236,16 @@ class TestSiteConfig:
 class TestSiteConfigLoad:
     def test_loads_from_toml_file(self):
         toml_content = b"""
-[py-ssg]
-name = "My Blog"
-url = "https://example.com"
-description = "A blog"
-cache = true
+        [py-ssg]
+        name = "My Blog"
+        url = "https://example.com"
+        description = "A blog"
+        static_dir = "public"
+        static_dir_output = "root"
+        cache = true
 
-[[py-ssg.authors]]
-name = "Jane"
+        [[py-ssg.authors]]
+        name = "Jane"
 email = "jane@example.com"
 
 [[py-ssg.feeds]]
@@ -247,6 +266,8 @@ theme_dark = "dracula"
         assert config.name == "My Blog"
         assert config.url == "https://example.com"
         assert config.description == "A blog"
+        assert config.static_dir == "public"
+        assert config.static_dir_output == "root"
         assert config.cache is True
         assert len(config.authors) == 1
         assert config.authors[0].name == "Jane"
@@ -275,6 +296,22 @@ cache = false
             config = SiteConfig.load(Path("/project"))
 
         assert config.cache is False
+
+    @patch(
+        f"{TEST_PATH}.open",
+        new_callable=mock_open,
+        read_data=b"""
+[py-ssg]
+static_dir_output = "invalid"
+""",
+    )
+    @patch(f"{TEST_PATH}.Path.exists", return_value=True)
+    def test_raises_for_invalid_static_dir_output(self, _mock_exists, _mock_file):
+        with pytest.raises(
+            ValueError,
+            match='Invalid static_dir_output value: "invalid". Supported modes: "static", "root".',
+        ):
+            SiteConfig.load(Path("/project"))
 
 
 class TestTocConfig:


### PR DESCRIPTION
SUMMARY

This change adds comprehensive static assets support to py-ssg with two configurable output modes and improves code organization through significant refactoring of the build process.

NEW FEATURES

Static Assets Management:
- Automatically copy static files from a source directory during build
- Two output modes: "static" copies to output/static/, "root" merges into output/
- Configurable source directory via static_dir setting (default: "static")
- File watching integration: server command watches static directory for changes when present
- Informational logging when assets are copied

IMPLEMENTATION

Configuration:
- Added static_dir and static_dir_output fields to SiteConfig with sensible defaults
- Updated configuration template with new static asset options
- Comprehensive documentation in README with examples and usage patterns

Code Organization:
- Introduced ProjectDirectory enum for consistent directory path management
- Introduced StaticDirOutputMode enum encapsulating output mode logic
- Refactored large BuildCommand.execute method into focused private methods
- New helper methods: _build_paths, _create_highlighter, _create_toc_generator, _parse_markdown, _render_templates, _copy_template_directories, _render_template_files, _write_syntax_stylesheet, _copy_static_assets, _generate_feeds, _print_summary
- Introduced BuildPaths and RenderSummary dataclasses for improved type clarity and testability

TESTING

Added 5 new test cases covering:
- Static directory copying to output/static/ with dirs_exist_ok behavior
- Root output mode merging assets directly into output/
- Handling of existing destination directories
- Informational logging output
- Helper method functionality (paths, highlighter, TOC generator creation)

Updated existing tests to include new configuration fields and maintain compatibility.

DOCUMENTATION

Updated README to include:
- Static assets directory in project structure examples
- Configuration options with explanations
- New Static Assets section with usage instructions and examples
- Updated hook documentation to reflect static asset handling