### PR TITLE
Add tag mapping support to template rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 
 - Type every method parameter explicitly.
 - Type return values explicitly.
+- Do not use `...` for typing.
 - Avoid introducing implicit `Any` in production code.
 - When adding helpers, keep signatures narrow and concrete.
 - If a shape becomes complex, such as nested `dict`, `list`, `tuple`, or mixed container data, introduce a dedicated type instead of passing raw nested structures around.

--- a/pyssg/commands/build.py
+++ b/pyssg/commands/build.py
@@ -1,10 +1,12 @@
 import os
 import shutil
 import time
-from collections.abc import Callable
+from collections import defaultdict
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
+from types import MappingProxyType
 
 from pyssg.commands.base_command import BaseCommand
 from pyssg.modules.build_script import BuildContext, BuildScript
@@ -97,6 +99,9 @@ class RenderSummary:
 class TemplateRenderResult:
     built: bool
     cached: bool
+
+
+type TagMap = Mapping[str, Sequence[MarkdownContent]]
 
 
 class BuildCommand(BaseCommand):
@@ -268,6 +273,7 @@ class BuildCommand(BaseCommand):
         built_files = 0
         cached_files = 0
         sorted_content = self._sort_content(collection, content_sort)
+        tag_map = self._build_tag_map(sorted_content)
 
         for filename in os.listdir(templates_dir):
             if not filename.endswith(".html"):
@@ -280,6 +286,7 @@ class BuildCommand(BaseCommand):
                 output_dir=output_dir,
                 engine=engine,
                 sorted_content=sorted_content,
+                tag_map=tag_map,
                 cache=cache,
             )
             if result.cached:
@@ -296,6 +303,7 @@ class BuildCommand(BaseCommand):
         output_dir: Path,
         engine: HtmlTemplateEngine,
         sorted_content: list[MarkdownContent],
+        tag_map: TagMap,
         cache: BuildCache,
     ) -> TemplateRenderResult:
         filepath = os.path.join(templates_dir, filename)
@@ -306,7 +314,10 @@ class BuildCommand(BaseCommand):
         if not is_dynamic and not cache.needs_rebuild(filename, template):
             return TemplateRenderResult(built=False, cached=True)
 
-        rendered = engine.render(template, context={"content": tuple(sorted_content)})
+        rendered = engine.render(
+            template,
+            context={"content": tuple(sorted_content), "tags": tag_map},
+        )
         output_path = os.path.join(output_dir, filename)
         with open(output_path, "w") as f:
             f.write(rendered)
@@ -329,6 +340,14 @@ class BuildCommand(BaseCommand):
         reverse = content_sort == "date_desc"
         sorted_dated = sorted(dated, key=lambda post: post.timestamp, reverse=reverse)
         return sorted_dated + undated
+
+    def _build_tag_map(self, sorted_content: list[MarkdownContent]) -> TagMap:
+        tag_map: defaultdict[str, list[MarkdownContent]] = defaultdict(list)
+        for post in sorted_content:
+            for tag in post.tags:
+                tag_map[tag].append(post)
+        frozen_tag_map = {tag: tuple(posts) for tag, posts in tag_map.items()}
+        return MappingProxyType(frozen_tag_map)
 
     def _write_syntax_stylesheet(
         self,

--- a/tests/app/commands/test_build.py
+++ b/tests/app/commands/test_build.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import MappingProxyType
 from unittest.mock import MagicMock, call, patch
 
 from pyssg.commands.build import (
@@ -289,6 +290,32 @@ def test_sort_content_supports_none() -> None:
     assert sorted_content == [first, second]
 
 
+def test_build_tag_map_groups_posts_by_tag_in_sorted_order() -> None:
+    command = SilentBuildCommand()
+    newest = MarkdownContent(
+        filename="newest.md",
+        html="",
+        timestamp="2025-01-01",
+        tags=["python", "release"],
+    )
+    older = MarkdownContent(
+        filename="older.md",
+        html="",
+        timestamp="2024-01-01",
+        tags=["python"],
+    )
+    undated = MarkdownContent(filename="undated.md", html="", tags=["notes"])
+
+    tag_map = command._build_tag_map([newest, older, undated])
+
+    assert isinstance(tag_map, MappingProxyType)
+    assert tag_map == {
+        "python": (newest, older),
+        "release": (newest,),
+        "notes": (undated,),
+    }
+
+
 @patch.object(BuildCommand, "_info")
 @patch(f"{TEST_PATH}.MarkdownParser")
 @patch(f"{TEST_PATH}.os.cpu_count")
@@ -384,13 +411,14 @@ def test_render_template_file_builds_static_template(tmp_path: Path) -> None:
         output_dir=output_dir,
         engine=engine,
         sorted_content=[post],
+        tag_map=MappingProxyType({"python": (post,)}),
         cache=cache,
     )
 
     assert result == TemplateRenderResult(built=True, cached=False)
     engine.render.assert_called_once_with(
         "<h1>Template</h1>",
-        context={"content": (post,)},
+        context={"content": (post,), "tags": MappingProxyType({"python": (post,)})},
     )
     cache.update.assert_called_once_with("index.html", "<h1>Template</h1>")
     assert (output_dir / "index.html").read_text(
@@ -416,6 +444,7 @@ def test_render_template_file_skips_unchanged_static_template(tmp_path: Path) ->
         output_dir=output_dir,
         engine=engine,
         sorted_content=[],
+        tag_map={},
         cache=cache,
     )
 
@@ -448,6 +477,7 @@ def test_render_template_file_does_not_update_cache_for_dynamic_templates(
         output_dir=output_dir,
         engine=engine,
         sorted_content=[],
+        tag_map={},
         cache=cache,
     )
 
@@ -510,6 +540,48 @@ def test_render_template_files_passes_immutable_sorted_content(tmp_path: Path) -
     render_context = engine.render.call_args.kwargs["context"]
     assert render_context["content"] == (newer, older)
     assert isinstance(render_context["content"], tuple)
+
+
+def test_render_template_files_passes_tags_mapping_to_templates(tmp_path: Path) -> None:
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "index.html").write_text("<h1>Home</h1>", encoding="utf-8")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    newer = MarkdownContent(
+        filename="new.md",
+        html="",
+        timestamp="2025-01-01",
+        tags=["python", "release"],
+    )
+    older = MarkdownContent(
+        filename="old.md",
+        html="",
+        timestamp="2024-01-01",
+        tags=["python"],
+    )
+    engine = MagicMock()
+    engine.render.return_value = "<h1>Rendered</h1>"
+    cache = MagicMock()
+    cache.has_dynamic_constructs.return_value = False
+    cache.needs_rebuild.return_value = True
+    command = SilentBuildCommand()
+
+    command._render_template_files(
+        templates_dir=templates_dir,
+        output_dir=output_dir,
+        engine=engine,
+        collection=_make_collection(older, newer),
+        cache=cache,
+        content_sort="date_desc",
+    )
+
+    render_context = engine.render.call_args.kwargs["context"]
+    assert isinstance(render_context["tags"], MappingProxyType)
+    assert render_context["tags"] == {
+        "python": (newer, older),
+        "release": (newer,),
+    }
 
 
 def test_write_syntax_stylesheet_writes_css_file(tmp_path: Path) -> None:


### PR DESCRIPTION
This commit introduces tag-based content organization for templates, enabling dynamic grouping and filtering of markdown content by tags. The implementation adds a new _build_tag_map method to the BuildCommand class that creates a mapping from tag names to lists of MarkdownContent objects, preserving the sorted order of content.

The tag map is constructed during the template rendering phase and passed to all templates via the rendering context under the "tags" key. This allows template authors to create tag-based indexes, archives, or filtered views of content without requiring additional processing.

Key changes include:

- New TagMap type alias for type clarity and consistency
- _build_tag_map method that groups sorted content by tags using a defaultdict
- Updated _render_template_files to build the tag map once and pass it to all template renders
- Updated _render_template to accept and forward the tag map in the rendering context
- Comprehensive test coverage including tag map construction, template context passing, and integration with the full render pipeline

The implementation maintains backward compatibility while providing templates with the additional context needed for advanced content organization patterns.