### PR TITLE
feat: add incremental content caching for markdown parsing

### DIFF
--- a/pyssg/commands/build.py
+++ b/pyssg/commands/build.py
@@ -130,6 +130,7 @@ class BuildCommand(BaseCommand):
         collection, parsing_time = self._parse_markdown(
             paths=paths,
             config=config,
+            cache=cache,
             render_markdown=render_markdown,
             toc_generator=toc_generator,
         )
@@ -185,6 +186,7 @@ class BuildCommand(BaseCommand):
         self,
         paths: BuildPaths,
         config: SiteConfig,
+        cache: BuildCache,
         render_markdown: Callable[[str], str] | None,
         toc_generator: TocGenerator | None,
     ) -> tuple[MarkdownCollection, float]:
@@ -192,20 +194,23 @@ class BuildCommand(BaseCommand):
         parsing_start = time.perf_counter()
         parser = MarkdownParser(
             content_dir=paths.project_dir / ProjectDirectory.CONTENT,
+            cache=cache,
             render_markdown=render_markdown,
             toc_generator=toc_generator,
         )
+        syntax_config = {
+            "enabled": config.syntax.enabled,
+            "theme_light": config.syntax.theme_light,
+            "theme_dark": config.syntax.theme_dark,
+        }
+        toc_config = {
+            "enabled": config.toc.enabled,
+            "max_depth": config.toc.max_depth,
+        }
         collection = parser.parse(
             workers=os.cpu_count() or 1,
-            syntax_config={
-                "enabled": config.syntax.enabled,
-                "theme_light": config.syntax.theme_light,
-                "theme_dark": config.syntax.theme_dark,
-            },
-            toc_config={
-                "enabled": config.toc.enabled,
-                "max_depth": config.toc.max_depth,
-            },
+            syntax_config=syntax_config,
+            toc_config=toc_config,
         )
         return collection, time.perf_counter() - parsing_start
 

--- a/pyssg/modules/cache.py
+++ b/pyssg/modules/cache.py
@@ -1,6 +1,9 @@
 import hashlib
 import json
+from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, cast
 
 from jinja2 import Environment, nodes
 
@@ -9,11 +12,32 @@ _jinja_env = Environment()
 DYNAMIC_NODE_TYPES = (nodes.For, nodes.If, nodes.Macro, nodes.CallBlock)
 
 
+type CachePayload = dict[str, object]
+
+
+@dataclass
+class CachedContentEntry:
+    hash_value: str
+    data: CachePayload
+
+    def to_dict(self) -> dict[str, object]:
+        return {"hash": self.hash_value, "data": self.data}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "CachedContentEntry" | None:
+        hash_value = data.get("hash")
+        entry_data = data.get("data")
+        if not isinstance(hash_value, str) or not isinstance(entry_data, dict):
+            return None
+        return cls(hash_value=hash_value, data=entry_data)
+
+
 class BuildCache:
     def __init__(self, cache_dir: Path, enabled: bool = True) -> None:
         self.cache_dir = cache_dir
         self.enabled = enabled
         self._entries: dict[str, str] = {}
+        self._content_entries: dict[str, CachedContentEntry] = {}
 
     def has_dynamic_constructs(self, template: str) -> bool:
         ast = _jinja_env.parse(template)
@@ -41,24 +65,112 @@ class BuildCache:
             return
         self._entries[filename] = self.compute_hash(content)
 
+    def _compute_content_hash(self, raw: str, config_key: str) -> str:
+        return self.compute_hash(f"{raw}\0{config_key}")
+
+    def get_content(
+        self, filename: str, raw: str, config_key: str
+    ) -> CachePayload | None:
+        if not self.enabled:
+            return None
+        entry = self._content_entries.get(filename)
+        if entry is None:
+            return None
+        expected_hash = self._compute_content_hash(raw, config_key)
+        if entry.hash_value != expected_hash:
+            return None
+        return entry.data
+
+    def set_content(
+        self, filename: str, raw: str, config_key: str, data: Mapping[str, object]
+    ) -> None:
+        if not self.enabled:
+            return
+        entry_hash = self._compute_content_hash(raw, config_key)
+        self._content_entries[filename] = CachedContentEntry(
+            hash_value=entry_hash,
+            data=dict(data),
+        )
+
+    def _cache_data(self) -> dict[str, object]:
+        return {
+            "templates": self._entries,
+            "content": {
+                filename: entry.to_dict()
+                for filename, entry in self._content_entries.items()
+            },
+        }
+
+    def _cache_path(self) -> Path:
+        return self.cache_dir / ".pyssg_cache.json"
+
+    def _ensure_cache_file(self) -> Path:
+        cache_path = self._cache_path()
+        if not cache_path.exists():
+            self.create(cache_dir=self.cache_dir)
+        return cache_path
+
+    def _reset_entries(self) -> None:
+        self._entries = {}
+        self._content_entries = {}
+
+    def _read_cache_data(self) -> object:
+        cache_path = self._ensure_cache_file()
+        with open(cache_path) as f:
+            return json.loads(f.read())
+
+    def _load_template_entries(self, data: dict[str, Any]) -> None:
+        self._entries = {
+            str(filename): str(entry_hash)
+            for filename, entry_hash in data.items()
+            if isinstance(filename, str) and isinstance(entry_hash, str)
+        }
+
+    def _load_content_entries(self, data: dict[str, Any]) -> None:
+        for filename, entry in data.items():
+            if not isinstance(filename, str) or not isinstance(entry, dict):
+                continue
+            parsed_entry = CachedContentEntry.from_dict(entry)
+            if parsed_entry is not None:
+                self._content_entries[filename] = parsed_entry
+
+    def _is_structured_cache_data(self, data: dict[str, Any]) -> bool:
+        templates = data.get("templates")
+        content = data.get("content")
+        return isinstance(templates, dict) or isinstance(content, dict)
+
+    def _load_structured_entries(self, data: dict[str, Any]) -> None:
+        templates = data.get("templates")
+        if isinstance(templates, dict):
+            self._load_template_entries(templates)
+        content = data.get("content")
+        if isinstance(content, dict):
+            self._load_content_entries(content)
+
+    def _load_entries(self, data: object) -> None:
+        self._reset_entries()
+        if not isinstance(data, dict):
+            return
+        cache_data = cast(dict[str, Any], data)
+        if self._is_structured_cache_data(cache_data):
+            self._load_structured_entries(cache_data)
+            return
+        self._load_template_entries(cache_data)
+
     @staticmethod
     def create(cache_dir: Path) -> None:
         cache_path = cache_dir / ".pyssg_cache.json"
         with open(cache_path, "w") as f:
-            f.write(json.dumps({}))
+            f.write(json.dumps({"templates": {}, "content": {}}))
 
     def save(self) -> None:
         if not self.enabled:
             return
-        cache_path = self.cache_dir / ".pyssg_cache.json"
+        cache_path = self._cache_path()
         with open(cache_path, "w") as f:
-            f.write(json.dumps(self._entries))
+            f.write(json.dumps(self._cache_data()))
 
     def load(self) -> None:
         if not self.enabled:
             return
-        cache_path = self.cache_dir / ".pyssg_cache.json"
-        if not cache_path.exists():
-            self.create(cache_dir=self.cache_dir)
-        with open(cache_path) as f:
-            self._entries = json.loads(f.read())
+        self._load_entries(self._read_cache_data())

--- a/pyssg/modules/markdown.py
+++ b/pyssg/modules/markdown.py
@@ -1,15 +1,18 @@
+import json
 import re
 from collections.abc import Callable, Iterator
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, TypedDict, cast
 from xml.etree.ElementTree import Element, SubElement, tostring
 
 import frontmatter
 import mistune
 from mistune.toc import add_toc_hook
+
+from pyssg.modules.cache import BuildCache
 
 _AUTHOR_KEYS = frozenset({"author", "author_email", "author_avatar", "author_url"})
 
@@ -19,6 +22,19 @@ def _slugify(text: str) -> str:
     slug = re.sub(r"[^\w\s-]", "", slug)
     slug = re.sub(r"[\s]+", "-", slug).strip("-")
     return slug
+
+
+def _to_json_safe_value(value: object) -> object:
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    if isinstance(value, list | tuple):
+        return [_to_json_safe_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            str(key): _to_json_safe_value(item_value)
+            for key, item_value in value.items()
+        }
+    return str(value)
 
 
 class TocGenerator:
@@ -79,6 +95,57 @@ class ContentAuthor:
             url=str(post.get("author_url", "")),
         )
 
+    def to_dict(self) -> "ContentAuthorData":
+        return {
+            "name": self.name,
+            "email": self.email,
+            "avatar": self.avatar,
+            "url": self.url,
+        }
+
+    @classmethod
+    def from_dict(cls, data: "ContentAuthorData") -> "ContentAuthor":
+        return cls(
+            name=str(data.get("name", "")),
+            email=str(data.get("email", "")),
+            avatar=str(data.get("avatar", "")),
+            url=str(data.get("url", "")),
+        )
+
+
+class ContentAuthorData(TypedDict):
+    name: str
+    email: str
+    avatar: str
+    url: str
+
+
+class MarkdownContentData(TypedDict):
+    filename: str
+    html: str
+    title: str
+    timestamp: str
+    tags: list[str]
+    author: ContentAuthorData
+    custom_fields: dict[str, object]
+    toc: str
+
+
+@dataclass(frozen=True)
+class ParallelParseConfig:
+    syntax_enabled: bool
+    theme_light: str
+    theme_dark: str
+    toc_enabled: bool
+    toc_max_depth: int
+
+
+@dataclass(frozen=True)
+class PendingParseItem:
+    index: int
+    filename: str
+    raw: str
+
 
 @dataclass
 class MarkdownContent:
@@ -123,6 +190,42 @@ class MarkdownContent:
             author=ContentAuthor.from_post(post),
             custom_fields=custom,
             toc=toc,
+        )
+
+    def to_dict(self) -> MarkdownContentData:
+        return {
+            "filename": self.filename,
+            "html": self.html,
+            "title": self.title,
+            "timestamp": self.timestamp,
+            "tags": list(self.tags),
+            "author": self.author.to_dict(),
+            "custom_fields": cast(
+                dict[str, object],
+                _to_json_safe_value(dict(vars(self.custom_fields))),
+            ),
+            "toc": self.toc,
+        }
+
+    @classmethod
+    def from_dict(cls, data: MarkdownContentData) -> "MarkdownContent":
+        raw_tags = data.get("tags", [])
+        tags = [str(tag) for tag in raw_tags] if isinstance(raw_tags, list) else []
+        custom_fields_data = data.get("custom_fields", {})
+        if not isinstance(custom_fields_data, dict):
+            custom_fields_data = {}
+        author_data = data.get("author", ContentAuthor().to_dict())
+        if not isinstance(author_data, dict):
+            author_data = ContentAuthor().to_dict()
+        return cls(
+            filename=str(data.get("filename", "")),
+            html=str(data.get("html", "")),
+            title=str(data.get("title", "")),
+            timestamp=str(data.get("timestamp", "")),
+            tags=tags,
+            author=ContentAuthor.from_dict(author_data),
+            custom_fields=SimpleNamespace(**cast(dict[str, Any], custom_fields_data)),
+            toc=str(data.get("toc", "")),
         )
 
 
@@ -182,10 +285,12 @@ class MarkdownParser:
     def __init__(
         self,
         content_dir: Path,
+        cache: BuildCache | None = None,
         render_markdown: Callable[[str], str] | None = None,
         toc_generator: TocGenerator | None = None,
     ) -> None:
         self.content_dir = content_dir
+        self.cache = cache
         self.render_markdown = render_markdown
         self.toc_generator = toc_generator
 
@@ -204,55 +309,159 @@ class MarkdownParser:
         syntax_config: dict[str, Any] | None = None,
         toc_config: dict[str, Any] | None = None,
     ) -> MarkdownCollection:
+        config_key = self._build_config_key(syntax_config, toc_config)
         if workers > 1 and (syntax_config is not None or toc_config is not None):
-            return self._parse_parallel(workers, syntax_config, toc_config)
-        return self._parse_sequential()
+            return self._parse_parallel(workers, config_key, syntax_config, toc_config)
+        return self._parse_sequential(config_key)
 
-    def _parse_sequential(self) -> MarkdownCollection:
+    def _build_config_key(
+        self,
+        syntax_config: dict[str, Any] | None,
+        toc_config: dict[str, Any] | None,
+    ) -> str:
+        return json.dumps(
+            {"syntax": syntax_config or {}, "toc": toc_config or {}},
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    def _get_cached_content(
+        self, filename: str, raw: str, config_key: str
+    ) -> MarkdownContent | None:
+        if self.cache is None:
+            return None
+        cached = self.cache.get_content(filename, raw, config_key)
+        if cached is None:
+            return None
+        return MarkdownContent.from_dict(cast(MarkdownContentData, cached))
+
+    def _cache_content(
+        self, filename: str, raw: str, config_key: str, content: MarkdownContent
+    ) -> None:
+        if self.cache is None:
+            return
+        self.cache.set_content(filename, raw, config_key, content.to_dict())
+
+    def _build_parallel_config(
+        self,
+        syntax_config: dict[str, Any] | None,
+        toc_config: dict[str, Any] | None,
+    ) -> ParallelParseConfig:
+        return ParallelParseConfig(
+            syntax_enabled=bool(syntax_config and syntax_config.get("enabled")),
+            theme_light=(
+                syntax_config.get("theme_light", "friendly")
+                if syntax_config
+                else "friendly"
+            ),
+            theme_dark=(
+                syntax_config.get("theme_dark", "monokai")
+                if syntax_config
+                else "monokai"
+            ),
+            toc_enabled=bool(toc_config and toc_config.get("enabled")),
+            toc_max_depth=toc_config.get("max_depth", 3) if toc_config else 3,
+        )
+
+    def _partition_cached_items(
+        self, items: list[tuple[str, str]], config_key: str
+    ) -> tuple[dict[int, MarkdownContent], list[PendingParseItem]]:
+        results: dict[int, MarkdownContent] = {}
+        pending_items: list[PendingParseItem] = []
+        for index, (filename, raw) in enumerate(items):
+            cached_content = self._get_cached_content(filename, raw, config_key)
+            if cached_content is not None:
+                results[index] = cached_content
+                continue
+            pending_items.append(
+                PendingParseItem(index=index, filename=filename, raw=raw)
+            )
+        return results, pending_items
+
+    def _worker_items(
+        self, pending_items: list[PendingParseItem]
+    ) -> list[tuple[str, str]]:
+        return [(item.filename, item.raw) for item in pending_items]
+
+    def _parse_pending_items(
+        self,
+        workers: int,
+        parallel_config: ParallelParseConfig,
+        pending_items: list[PendingParseItem],
+    ) -> Iterator[MarkdownContent]:
+        with ProcessPoolExecutor(
+            max_workers=workers,
+            initializer=_init_worker,
+            initargs=(
+                parallel_config.syntax_enabled,
+                parallel_config.theme_light,
+                parallel_config.theme_dark,
+                parallel_config.toc_enabled,
+                parallel_config.toc_max_depth,
+            ),
+        ) as executor:
+            yield from executor.map(
+                _parse_file_worker,
+                self._worker_items(pending_items),
+                chunksize=64,
+            )
+
+    def _store_parsed_results(
+        self,
+        results: dict[int, MarkdownContent],
+        pending_items: list[PendingParseItem],
+        parsed_contents: Iterator[MarkdownContent],
+        config_key: str,
+    ) -> None:
+        for pending_item, content in zip(pending_items, parsed_contents):
+            results[pending_item.index] = content
+            self._cache_content(content.filename, pending_item.raw, config_key, content)
+
+    def _build_collection_from_results(
+        self, item_count: int, results: dict[int, MarkdownContent]
+    ) -> MarkdownCollection:
+        collection = MarkdownCollection()
+        for index in range(item_count):
+            collection.add(results[index])
+        return collection
+
+    def _parse_sequential(self, config_key: str) -> MarkdownCollection:
         collection = MarkdownCollection()
         for filename, raw in self._read_files():
-            collection.add(
-                MarkdownContent.from_raw(
-                    filename,
-                    raw,
-                    render_markdown=self.render_markdown,
-                    toc_generator=self.toc_generator,
-                )
+            cached_content = self._get_cached_content(filename, raw, config_key)
+            if cached_content is not None:
+                collection.add(cached_content)
+                continue
+            content = MarkdownContent.from_raw(
+                filename,
+                raw,
+                render_markdown=self.render_markdown,
+                toc_generator=self.toc_generator,
             )
+            self._cache_content(filename, raw, config_key, content)
+            collection.add(content)
         return collection
 
     def _parse_parallel(
         self,
         workers: int,
+        config_key: str,
         syntax_config: dict[str, Any] | None,
         toc_config: dict[str, Any] | None,
     ) -> MarkdownCollection:
         items = self._read_files()
-
-        syntax_enabled = bool(syntax_config and syntax_config.get("enabled"))
-        theme_light = (
-            syntax_config.get("theme_light", "friendly")
-            if syntax_config
-            else "friendly"
-        )
-        theme_dark = (
-            syntax_config.get("theme_dark", "monokai") if syntax_config else "monokai"
-        )
-        toc_enabled = bool(toc_config and toc_config.get("enabled"))
-        toc_max_depth = toc_config.get("max_depth", 3) if toc_config else 3
-
-        collection = MarkdownCollection()
-        with ProcessPoolExecutor(
-            max_workers=workers,
-            initializer=_init_worker,
-            initargs=(
-                syntax_enabled,
-                theme_light,
-                theme_dark,
-                toc_enabled,
-                toc_max_depth,
-            ),
-        ) as executor:
-            for content in executor.map(_parse_file_worker, items, chunksize=64):
-                collection.add(content)
-        return collection
+        parallel_config = self._build_parallel_config(syntax_config, toc_config)
+        results, pending_items = self._partition_cached_items(items, config_key)
+        if pending_items:
+            parsed_contents = self._parse_pending_items(
+                workers,
+                parallel_config,
+                pending_items,
+            )
+            self._store_parsed_results(
+                results,
+                pending_items,
+                parsed_contents,
+                config_key,
+            )
+        return self._build_collection_from_results(len(items), results)

--- a/tests/app/commands/test_build.py
+++ b/tests/app/commands/test_build.py
@@ -95,6 +95,7 @@ class RecordingBuildCommand(BuildCommand):
         self,
         paths: BuildPaths,
         config: SiteConfig,
+        cache,
         render_markdown,
         toc_generator,
     ) -> tuple[MarkdownCollection, float]:
@@ -338,10 +339,12 @@ def test_parse_markdown_configures_parser_and_returns_timing(
         toc=TocConfig(enabled=True, max_depth=2),
     )
     command = BuildCommand()
+    cache = MagicMock()
 
     parsed_collection, parsing_time = command._parse_markdown(
         paths=paths,
         config=config,
+        cache=cache,
         render_markdown=None,
         toc_generator=None,
     )
@@ -351,6 +354,7 @@ def test_parse_markdown_configures_parser_and_returns_timing(
     mock_info.assert_called_once_with("Parsing markdown files...")
     mock_parser_cls.assert_called_once_with(
         content_dir=Path("/project/content"),
+        cache=cache,
         render_markdown=None,
         toc_generator=None,
     )

--- a/tests/app/modules/test_cache.py
+++ b/tests/app/modules/test_cache.py
@@ -1,9 +1,10 @@
 import hashlib
 import json
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import mock_open, patch
 
-from pyssg.modules.cache import BuildCache
+from pyssg.modules.cache import BuildCache, CachedContentEntry
 
 TEST_PATH = "pyssg.modules.cache"
 
@@ -92,6 +93,14 @@ class TestComputeHash:
 
         assert hash1 == hash2
 
+    def test_content_hash_distinguishes_ambiguous_raw_and_config_pairs(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+
+        hash1 = cache._compute_content_hash("ab", "c")
+        hash2 = cache._compute_content_hash("a", "bc")
+
+        assert hash1 != hash2
+
 
 class TestNeedsRebuild:
     def test_returns_true_for_new_file(self):
@@ -140,7 +149,54 @@ class TestCreate:
 
         m.assert_called_once_with(Path("/project/.pyssg_cache.json"), "w")
         written = m().write.call_args[0][0]
-        assert json.loads(written) == {}
+        assert json.loads(written) == {"templates": {}, "content": {}}
+
+
+class TestCacheFileHelpers:
+    def test_cache_path_uses_project_cache_filename(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+
+        assert cache._cache_path() == Path("/project/.pyssg_cache.json")
+
+    def test_ensure_cache_file_returns_existing_path_without_creating(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+
+        with (
+            patch(f"{TEST_PATH}.Path.exists", return_value=True),
+            patch.object(BuildCache, "create") as mock_create,
+        ):
+            cache_path = cache._ensure_cache_file()
+
+        assert cache_path == Path("/project/.pyssg_cache.json")
+        mock_create.assert_not_called()
+
+    def test_ensure_cache_file_creates_missing_file(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+
+        with (
+            patch(f"{TEST_PATH}.Path.exists", return_value=False),
+            patch.object(BuildCache, "create") as mock_create,
+        ):
+            cache_path = cache._ensure_cache_file()
+
+        assert cache_path == Path("/project/.pyssg_cache.json")
+        mock_create.assert_called_once_with(cache_dir=Path("/project"))
+
+    def test_read_cache_data_reads_json_from_cache_file(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+        cache_data = {"templates": {"index.html": "abc"}, "content": {}}
+
+        with (
+            patch.object(
+                BuildCache,
+                "_ensure_cache_file",
+                return_value=Path("/project/.pyssg_cache.json"),
+            ),
+            patch(f"{TEST_PATH}.open", mock_open(read_data=json.dumps(cache_data))),
+        ):
+            result = cache._read_cache_data()
+
+        assert result == cache_data
 
 
 class TestSave:
@@ -155,11 +211,177 @@ class TestSave:
         m.assert_called_once_with(Path("/project/.pyssg_cache.json"), "w")
         written = m().write.call_args[0][0]
         data = json.loads(written)
-        assert "index.html" in data
+        assert "index.html" in data["templates"]
+
+    def test_writes_content_cache_to_json_file(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+        cache.set_content(
+            "post.md",
+            "# Hello",
+            '{"syntax":{},"toc":{}}',
+            {
+                "filename": "post.md",
+                "html": "<h1>Hello</h1>",
+                "title": "",
+                "timestamp": "",
+                "tags": [],
+                "author": {"name": "", "email": "", "avatar": "", "url": ""},
+                "custom_fields": {},
+                "toc": "",
+            },
+        )
+
+        m = mock_open()
+        with patch(f"{TEST_PATH}.open", m):
+            cache.save()
+
+        written = m().write.call_args[0][0]
+        data = json.loads(written)
+        assert data["content"]["post.md"]["data"]["html"] == "<h1>Hello</h1>"
 
 
 class TestLoad:
-    def test_loads_cache_from_json_file(self):
+    def test_reset_entries_clears_template_and_content_entries(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+        cache._entries["index.html"] = "abc"
+        cache._content_entries["post.md"] = CachedContentEntry(
+            hash_value="abc123",
+            data={"html": "<p>Body</p>"},
+        )
+
+        cache._reset_entries()
+
+        assert cache._entries == {}
+        assert cache._content_entries == {}
+
+    def test_is_structured_cache_data_detects_templates_key(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+
+        assert cache._is_structured_cache_data({"templates": {}}) is True
+
+    def test_is_structured_cache_data_detects_content_key(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+
+        assert cache._is_structured_cache_data({"content": {}}) is True
+
+    def test_is_structured_cache_data_returns_false_for_legacy_shape(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+
+        assert cache._is_structured_cache_data({"index.html": "abc123"}) is False
+
+    def test_load_template_entries_ignores_invalid_items(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+
+        cache._load_template_entries(
+            cast(dict[str, Any], {"index.html": "abc123", "about.html": 1, 2: "skip"})
+        )
+
+        assert cache._entries == {"index.html": "abc123"}
+
+    def test_load_content_entries_ignores_invalid_items(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+
+        cache._load_content_entries(
+            cast(
+                dict[str, Any],
+                {
+                    "post.md": {"hash": "abc123", "data": {"html": "<p>Body</p>"}},
+                    "bad.md": {"hash": 1, "data": {}},
+                    "skip.md": "invalid",
+                    2: {"hash": "def456", "data": {}},
+                },
+            )
+        )
+
+        assert list(cache._content_entries) == ["post.md"]
+        assert cache._content_entries["post.md"].hash_value == "abc123"
+
+    def test_load_entries_resets_existing_state_before_loading_structured_data(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+        cache._entries["stale.html"] = "stale"
+        cache._content_entries["stale.md"] = CachedContentEntry(
+            hash_value="stale",
+            data={"html": "<p>Stale</p>"},
+        )
+
+        cache._load_entries({"templates": {"index.html": "abc123"}, "content": {}})
+
+        assert cache._entries == {"index.html": "abc123"}
+        assert cache._content_entries == {}
+
+    def test_load_entries_resets_existing_state_before_loading_legacy_data(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+        cache._entries["stale.html"] = "stale"
+        cache._content_entries["stale.md"] = CachedContentEntry(
+            hash_value="stale",
+            data={"html": "<p>Stale</p>"},
+        )
+
+        cache._load_entries({"index.html": "abc123"})
+
+        assert cache._entries == {"index.html": "abc123"}
+        assert cache._content_entries == {}
+
+    def test_load_entries_ignores_non_dict_data(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+        cache._entries["stale.html"] = "stale"
+        cache._content_entries["stale.md"] = CachedContentEntry(
+            hash_value="stale",
+            data={"html": "<p>Stale</p>"},
+        )
+
+        cache._load_entries(["not", "a", "dict"])
+
+        assert cache._entries == {}
+        assert cache._content_entries == {}
+
+    def test_loads_template_cache_from_structured_json_file(self):
+        expected_hash = hashlib.sha256("<h1>Hello</h1>".encode()).hexdigest()
+        cache_data = json.dumps(
+            {"templates": {"index.html": expected_hash}, "content": {}}
+        )
+        cache = BuildCache(cache_dir=Path("/project"))
+
+        with patch(f"{TEST_PATH}.open", mock_open(read_data=cache_data)):
+            cache.load()
+
+        assert cache._entries["index.html"] == expected_hash
+
+    def test_loads_content_cache_from_structured_json_file(self):
+        cache_data = json.dumps(
+            {
+                "templates": {},
+                "content": {
+                    "post.md": {
+                        "hash": "abc123",
+                        "data": {
+                            "filename": "post.md",
+                            "html": "<p>Body</p>",
+                            "title": "Post",
+                            "timestamp": "",
+                            "tags": ["python"],
+                            "author": {
+                                "name": "Jane",
+                                "email": "",
+                                "avatar": "",
+                                "url": "",
+                            },
+                            "custom_fields": {"draft": True},
+                            "toc": "",
+                        },
+                    }
+                },
+            }
+        )
+        cache = BuildCache(cache_dir=Path("/project"))
+
+        with patch(f"{TEST_PATH}.open", mock_open(read_data=cache_data)):
+            cache.load()
+
+        assert cache._content_entries["post.md"].hash_value == "abc123"
+        assert cache._content_entries["post.md"].data["title"] == "Post"
+
+    def test_loads_legacy_template_cache_json_file(self):
         expected_hash = hashlib.sha256("<h1>Hello</h1>".encode()).hexdigest()
         cache_data = json.dumps({"index.html": expected_hash})
         cache = BuildCache(cache_dir=Path("/project"))
@@ -181,6 +403,66 @@ class TestLoad:
 
         mock_create.assert_called_once_with(cache_dir=Path("/project"))
         assert cache._entries == {}
+
+
+class TestContentCache:
+    def test_get_content_returns_none_for_new_file(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+
+        assert cache.get_content("post.md", "# Hello", '{"syntax":{},"toc":{}}') is None
+
+    def test_get_content_returns_data_for_unchanged_file(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+        data = {
+            "filename": "post.md",
+            "html": "<p>Hello</p>",
+            "title": "",
+            "timestamp": "",
+            "tags": [],
+            "author": {"name": "", "email": "", "avatar": "", "url": ""},
+            "custom_fields": {},
+            "toc": "",
+        }
+
+        cache.set_content("post.md", "# Hello", '{"syntax":{},"toc":{}}', data)
+
+        assert cache.get_content("post.md", "# Hello", '{"syntax":{},"toc":{}}') == data
+
+    def test_get_content_returns_none_for_changed_file(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+        data = {
+            "filename": "post.md",
+            "html": "<p>Hello</p>",
+            "title": "",
+            "timestamp": "",
+            "tags": [],
+            "author": {"name": "", "email": "", "avatar": "", "url": ""},
+            "custom_fields": {},
+            "toc": "",
+        }
+
+        cache.set_content("post.md", "# Hello", '{"syntax":{},"toc":{}}', data)
+
+        assert (
+            cache.get_content("post.md", "# Changed", '{"syntax":{},"toc":{}}') is None
+        )
+
+    def test_get_content_rejects_ambiguous_concat_pair_with_different_inputs(self):
+        cache = BuildCache(cache_dir=Path("/project"))
+        data = {
+            "filename": "post.md",
+            "html": "<p>Hello</p>",
+            "title": "",
+            "timestamp": "",
+            "tags": [],
+            "author": {"name": "", "email": "", "avatar": "", "url": ""},
+            "custom_fields": {},
+            "toc": "",
+        }
+
+        cache.set_content("post.md", "ab", "c", data)
+
+        assert cache.get_content("post.md", "a", "bc") is None
 
 
 class TestEnabled:

--- a/tests/app/modules/test_markdown.py
+++ b/tests/app/modules/test_markdown.py
@@ -1,10 +1,16 @@
+import json
+from datetime import date, datetime
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
+from pyssg.modules.cache import BuildCache
 from pyssg.modules.markdown import (
     ContentAuthor,
     MarkdownCollection,
     MarkdownContent,
     MarkdownParser,
+    ParallelParseConfig,
+    PendingParseItem,
     TocGenerator,
 )
 
@@ -41,6 +47,16 @@ class TestContentAuthor:
         author = ContentAuthor.from_post(post)
 
         assert author == ContentAuthor()
+
+    def test_to_dict_round_trips_with_from_dict(self):
+        author = ContentAuthor(
+            name="Jane",
+            email="jane@example.com",
+            avatar="avatar.png",
+            url="https://example.com",
+        )
+
+        assert ContentAuthor.from_dict(author.to_dict()) == author
 
 
 class TestMarkdownContent:
@@ -101,6 +117,48 @@ class TestMarkdownContent:
         assert content.title == ""
         assert content.tags == []
         assert "<p>Just plain markdown</p>" in content.html
+
+    def test_to_dict_round_trips_with_from_dict(self):
+        content = MarkdownContent(
+            filename="post.md",
+            html="<p>Hello</p>",
+            title="Post",
+            timestamp="2025-01-15",
+            tags=["python"],
+            author=ContentAuthor(name="Jane", email="jane@example.com"),
+            custom_fields=SimpleNamespace(slug="post", draft=True),
+            toc="<nav>...</nav>",
+        )
+
+        restored = MarkdownContent.from_dict(content.to_dict())
+
+        assert restored == content
+
+    def test_to_dict_normalizes_non_json_custom_fields(self):
+        content = MarkdownContent(
+            filename="post.md",
+            html="<p>Hello</p>",
+            custom_fields=SimpleNamespace(
+                published_on=date(2025, 1, 15),
+                updated_at=datetime(2025, 1, 15, 12, 30, 45),
+                metadata={
+                    "reviewed_on": date(2025, 1, 16),
+                    "history": [datetime(2025, 1, 17, 8, 0, 0)],
+                },
+            ),
+        )
+
+        data = content.to_dict()
+
+        assert data["custom_fields"] == {
+            "published_on": "2025-01-15",
+            "updated_at": "2025-01-15 12:30:45",
+            "metadata": {
+                "reviewed_on": "2025-01-16",
+                "history": ["2025-01-17 08:00:00"],
+            },
+        }
+        json.dumps(data)
 
 
 class TestMarkdownCollection:
@@ -212,6 +270,163 @@ class TestParse:
         assert "docs/api.md" in result
         assert result["blog/2025/post.md"].filename == "blog/2025/post.md"
         assert result["docs/api.md"].filename == "docs/api.md"
+
+    @patch("pyssg.modules.markdown.MarkdownContent.from_raw")
+    def test_uses_cached_content_in_sequential_mode(
+        self, mock_from_raw: MagicMock, tmp_path
+    ):
+        raw = "# Hello\n\nWorld"
+        (tmp_path / "post.md").write_text(raw)
+        cache = BuildCache(cache_dir=tmp_path)
+        cached_content = MarkdownContent(
+            filename="post.md",
+            html="<p>cached</p>",
+            title="Cached",
+        )
+        config_key = json.dumps(
+            {"syntax": {}, "toc": {}}, sort_keys=True, separators=(",", ":")
+        )
+        cache.set_content("post.md", raw, config_key, cached_content.to_dict())
+        parser = MarkdownParser(content_dir=tmp_path, cache=cache)
+
+        result = parser.parse()
+
+        mock_from_raw.assert_not_called()
+        assert result["post.md"] == cached_content
+
+    @patch("pyssg.modules.markdown.ProcessPoolExecutor")
+    def test_parallel_mode_only_dispatches_uncached_files(
+        self, mock_executor_cls: MagicMock, tmp_path
+    ):
+        raw_a = "# Cached"
+        raw_b = "# Fresh"
+        (tmp_path / "a.md").write_text(raw_a)
+        (tmp_path / "b.md").write_text(raw_b)
+        cache = BuildCache(cache_dir=tmp_path)
+        cached_content = MarkdownContent(filename="a.md", html="<p>cached</p>")
+        config_key = json.dumps(
+            {
+                "syntax": {"enabled": False},
+                "toc": {"enabled": False},
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        cache.set_content("a.md", raw_a, config_key, cached_content.to_dict())
+        fresh_content = MarkdownContent(filename="b.md", html="<p>fresh</p>")
+        mock_executor = mock_executor_cls.return_value.__enter__.return_value
+        mock_executor.map.return_value = [fresh_content]
+        parser = MarkdownParser(content_dir=tmp_path, cache=cache)
+
+        result = parser.parse(
+            workers=2,
+            syntax_config={"enabled": False},
+            toc_config={"enabled": False},
+        )
+
+        mock_executor.map.assert_called_once_with(
+            mock_executor.map.call_args.args[0],
+            [("b.md", raw_b)],
+            chunksize=64,
+        )
+        assert list(result) == [cached_content, fresh_content]
+        assert cache.get_content("b.md", raw_b, config_key) == fresh_content.to_dict()
+
+
+class TestParallelHelpers:
+    def test_build_parallel_config_uses_defaults(self, tmp_path):
+        parser = MarkdownParser(content_dir=tmp_path)
+
+        config = parser._build_parallel_config(None, None)
+
+        assert config == ParallelParseConfig(
+            syntax_enabled=False,
+            theme_light="friendly",
+            theme_dark="monokai",
+            toc_enabled=False,
+            toc_max_depth=3,
+        )
+
+    def test_build_parallel_config_uses_provided_values(self, tmp_path):
+        parser = MarkdownParser(content_dir=tmp_path)
+
+        config = parser._build_parallel_config(
+            {"enabled": True, "theme_light": "tango", "theme_dark": "dracula"},
+            {"enabled": True, "max_depth": 5},
+        )
+
+        assert config == ParallelParseConfig(
+            syntax_enabled=True,
+            theme_light="tango",
+            theme_dark="dracula",
+            toc_enabled=True,
+            toc_max_depth=5,
+        )
+
+    def test_partition_cached_items_splits_cached_and_pending(self, tmp_path):
+        raw_a = "# Cached"
+        raw_b = "# Fresh"
+        cache = BuildCache(cache_dir=tmp_path)
+        parser = MarkdownParser(content_dir=tmp_path, cache=cache)
+        config_key = json.dumps(
+            {"syntax": {}, "toc": {}}, sort_keys=True, separators=(",", ":")
+        )
+        cached_content = MarkdownContent(filename="a.md", html="<p>cached</p>")
+        cache.set_content("a.md", raw_a, config_key, cached_content.to_dict())
+
+        results, pending_items = parser._partition_cached_items(
+            [("a.md", raw_a), ("b.md", raw_b)],
+            config_key,
+        )
+
+        assert results == {0: cached_content}
+        assert pending_items == [PendingParseItem(index=1, filename="b.md", raw=raw_b)]
+
+    def test_worker_items_extract_filename_and_raw(self, tmp_path):
+        parser = MarkdownParser(content_dir=tmp_path)
+        pending_items = [
+            PendingParseItem(index=1, filename="b.md", raw="# Fresh"),
+            PendingParseItem(index=2, filename="c.md", raw="# New"),
+        ]
+
+        assert parser._worker_items(pending_items) == [
+            ("b.md", "# Fresh"),
+            ("c.md", "# New"),
+        ]
+
+    def test_store_parsed_results_preserves_index_and_updates_cache(self, tmp_path):
+        cache = BuildCache(cache_dir=tmp_path)
+        parser = MarkdownParser(content_dir=tmp_path, cache=cache)
+        config_key = json.dumps(
+            {"syntax": {}, "toc": {}}, sort_keys=True, separators=(",", ":")
+        )
+        results: dict[int, MarkdownContent] = {}
+        pending_items = [PendingParseItem(index=1, filename="b.md", raw="# Fresh")]
+        parsed_contents = iter([MarkdownContent(filename="b.md", html="<p>fresh</p>")])
+
+        parser._store_parsed_results(
+            results,
+            pending_items,
+            parsed_contents,
+            config_key,
+        )
+
+        assert results == {1: MarkdownContent(filename="b.md", html="<p>fresh</p>")}
+        assert (
+            cache.get_content("b.md", "# Fresh", config_key)
+            == MarkdownContent(filename="b.md", html="<p>fresh</p>").to_dict()
+        )
+
+    def test_build_collection_from_results_restores_original_order(self, tmp_path):
+        parser = MarkdownParser(content_dir=tmp_path)
+        results = {
+            0: MarkdownContent(filename="a.md", html="<p>a</p>"),
+            1: MarkdownContent(filename="b.md", html="<p>b</p>"),
+        }
+
+        collection = parser._build_collection_from_results(2, results)
+
+        assert list(collection) == [results[0], results[1]]
 
 
 class TestParseFrontmatter:


### PR DESCRIPTION
This change extends the build cache to store parsed markdown content, enabling incremental builds that skip re-parsing unchanged files. Previously, the cache only tracked template changes; now it also stores the complete parsed output (HTML, metadata, table of contents) keyed by content hash and configuration.

When content files are unchanged and configuration hasn't shifted, the parser retrieves the cached result instead of re-rendering. This optimization applies to both sequential and parallel parsing modes. In parallel mode, the system partitions files into cached and pending items, dispatching only the uncached files to worker processes.

Implementation details:
- Added CachedContentEntry to structure cache entries with content hash and payload
- Extended BuildCache with get_content and set_content methods for managing content entries
- Refactored cache serialization to store templates and content in separate namespaces, supporting migration from the legacy flat schema
- Added to_dict and from_dict methods to MarkdownContent and ContentAuthor for serialization
- Refactored MarkdownParser to accept an optional cache instance and leverage it in both parsing modes
- Introduced ParallelParseConfig and PendingParseItem to simplify parallel execution and cache partitioning

The cache key incorporates both the file content and the active configuration (syntax highlighting and table of contents settings), ensuring correctness across configuration changes. Legacy cache files are automatically migrated to the new structure on load.