### PR TITLE
Add automatic patch version bumping to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: write
+
 jobs:
   lint:
     name: Lint
@@ -47,3 +50,62 @@ jobs:
 
       - name: pytest
         run: uv run pytest
+
+  bump-version:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    if: github.event_name == 'push' && github.actor != 'github-actions[bot]'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Bump patch version
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import re
+
+          pyproject = Path("pyproject.toml")
+          content = pyproject.read_text()
+          match = re.search(r'^version = "(\d+)\.(\d+)\.(\d+)"$', content, re.MULTILINE)
+          if match is None:
+              raise SystemExit("Unable to find version in pyproject.toml")
+
+          major, minor, patch = (int(part) for part in match.groups())
+          new_version = f'{major}.{minor}.{patch + 1}'
+          updated = re.sub(
+              r'^version = "\d+\.\d+\.\d+"$',
+              f'version = "{new_version}"',
+              content,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          pyproject.write_text(updated)
+          print(new_version)
+          PY
+
+      - name: Commit version bump
+        run: |
+          new_version="$(python - <<'PY'
+          from pathlib import Path
+          import re
+
+          content = Path("pyproject.toml").read_text()
+          match = re.search(r'^version = "(\d+\.\d+\.\d+)"$', content, re.MULTILINE)
+          if match is None:
+              raise SystemExit("Unable to read bumped version")
+          print(match.group(1))
+          PY
+          )"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump version to ${new_version} [skip ci]"
+          git push

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py-ssg"
-version = "0.1.0"
+version = "0.2.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ wheels = [
 
 [[package]]
 name = "py-ssg"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
This change implements automatic semantic versioning in the CI pipeline by adding a new bump-version job that automatically increments the patch version in pyproject.toml after successful lint and test runs on the main branch.

Changes include:

- Added contents:write permission to the workflow to allow the CI job to commit and push changes
- Created a new bump-version job that runs after lint and test pass on push events
- The job extracts the current version from pyproject.toml, increments the patch component, and commits the update back to the repository
- Excludes commits triggered by github-actions[bot] to prevent version bump loops
- Updated pyproject.toml and uv.lock to version 0.2.0 as the first bumped version

This ensures that every successful merge to main automatically increments the patch version, maintaining consistent versioning without manual intervention.