### PR TITLE
Implement dry-run and verbose modes with refactored output system

### DIFF
--- a/pyssg/commands/base_command.py
+++ b/pyssg/commands/base_command.py
@@ -5,20 +5,45 @@ from rich import print as rich_print
 
 
 class BaseCommand:
-    def _print_block(self, message: str, color: str) -> None:
-        term_length = shutil.get_terminal_size().columns
-        content_width = term_length - 1
-        text_width = content_width - 4  # 2-char padding on each side
+    _verbose: bool = False
+    _dry_run: bool = False
 
-        padding_line = f"[bold {color}]┃[/bold {color}]{' ' * content_width}"
-        rich_print(padding_line)
-        for chunk in textwrap.wrap(message, width=text_width) or [""]:
-            padded = f"  {chunk:<{text_width}}  "
-            rich_print(f"[bold {color}]┃{padded}[/bold {color}]")
-        rich_print(padding_line)
+    def __init__(self, *, verbose: bool = False, dry_run: bool = False) -> None:
+        self._verbose = verbose
+        self._dry_run = dry_run
+
+    def _status_prefix(self, color: str) -> str:
+        labels = {
+            "blue": "INFO",
+            "green": "DONE",
+            "yellow": "WARN",
+            "red": "FAIL",
+        }
+        label = labels.get(color, "LOG")
+        return f"[bold {color}][{label}][/bold {color}]"
+
+    def _print_block(self, message: str, color: str) -> None:
+        prefix = self._status_prefix(color)
+        available_width = max(shutil.get_terminal_size().columns - 8, 20)
+        message_width = max(available_width - len("INFO"), 12)
+        wrapped_lines = textwrap.wrap(message, width=message_width) or [""]
+
+        for index, line in enumerate(wrapped_lines):
+            if index == 0:
+                if line:
+                    rich_print(f"{prefix} {line}")
+                else:
+                    rich_print(prefix)
+                continue
+            rich_print(f"{' ' * (len(prefix) + 1)}{line}")
 
     def _info(self, message: str) -> None:
         self._print_block(message, color="blue")
+
+    def _detail(self, message: str) -> None:
+        if not self._verbose:
+            return
+        self._info(message)
 
     def _success(self, message: str) -> None:
         self._print_block(message, color="green")

--- a/pyssg/commands/build.py
+++ b/pyssg/commands/build.py
@@ -105,6 +105,9 @@ type TagMap = Mapping[str, Sequence[MarkdownContent]]
 
 
 class BuildCommand(BaseCommand):
+    def __init__(self, *, verbose: bool = False, dry_run: bool = False) -> None:
+        super().__init__(verbose=verbose, dry_run=dry_run)
+
     def execute(self) -> None:
         start_time = time.perf_counter()
         paths = self._build_paths()
@@ -112,6 +115,13 @@ class BuildCommand(BaseCommand):
         cache = BuildCache(cache_dir=paths.project_dir, enabled=config.cache)
         cache.load()
         build_script = BuildScript(paths.project_dir)
+        if self._dry_run:
+            self._warning(
+                "Dry run enabled: output files and build hooks will be skipped"
+            )
+        self._detail(f"Project directory: {paths.project_dir}")
+        self._detail(f"Output directory: {paths.output_dir}")
+        self._detail(f"Cache enabled: {config.cache}")
         context = BuildContext(
             config=config,
             cache=cache,
@@ -121,12 +131,14 @@ class BuildCommand(BaseCommand):
             output_dir=paths.output_dir,
         )
 
-        build_script.before_build(context)
+        if not self._dry_run:
+            build_script.before_build(context)
         highlighter = self._create_highlighter(config)
         render_markdown = highlighter.render_markdown if highlighter else None
         toc_generator = self._create_toc_generator(config)
 
-        build_script.before_markdown_parsing(context)
+        if not self._dry_run:
+            build_script.before_markdown_parsing(context)
         collection, parsing_time = self._parse_markdown(
             paths=paths,
             config=config,
@@ -135,7 +147,8 @@ class BuildCommand(BaseCommand):
         )
         context.content = collection
 
-        build_script.before_component_parsing(context)
+        if not self._dry_run:
+            build_script.before_component_parsing(context)
         render_summary = self._render_templates(
             paths=paths,
             config=config,
@@ -149,8 +162,9 @@ class BuildCommand(BaseCommand):
             collection=collection,
         )
 
-        cache.save()
-        build_script.after_build(context)
+        if not self._dry_run:
+            cache.save()
+            build_script.after_build(context)
         total_time = time.perf_counter() - start_time
         self._print_summary(
             render_summary=render_summary,
@@ -188,7 +202,7 @@ class BuildCommand(BaseCommand):
         render_markdown: Callable[[str], str] | None,
         toc_generator: TocGenerator | None,
     ) -> tuple[MarkdownCollection, float]:
-        self._info("Parsing markdown files...")
+        self._info("Parsing markdown content")
         parsing_start = time.perf_counter()
         parser = MarkdownParser(
             content_dir=paths.project_dir / ProjectDirectory.CONTENT,
@@ -217,7 +231,7 @@ class BuildCommand(BaseCommand):
         collection: MarkdownCollection,
         highlighter: SyntaxHighlighter | None,
     ) -> RenderSummary:
-        self._info("Rendering templates...")
+        self._info("Rendering templates")
         rendering_start = time.perf_counter()
         component_names = _discover_components(paths.components_dir)
         engine = HtmlTemplateEngine(
@@ -226,9 +240,16 @@ class BuildCommand(BaseCommand):
             component_names=component_names,
             config=config,
         )
-        os.makedirs(paths.output_dir, exist_ok=True)
+        self._detail(f"Discovered {len(component_names)} components")
+        if not self._dry_run:
+            os.makedirs(paths.output_dir, exist_ok=True)
 
-        self._copy_template_directories(paths)
+        if self._dry_run:
+            self._detail(
+                f"Dry run: would copy template directories into {paths.output_dir}"
+            )
+        else:
+            self._copy_template_directories(paths)
         total_files, built_files, cached_files = self._render_template_files(
             templates_dir=paths.templates_dir,
             output_dir=paths.output_dir,
@@ -237,10 +258,20 @@ class BuildCommand(BaseCommand):
             cache=cache,
             content_sort=config.content_sort,
         )
-        self._write_syntax_stylesheet(
-            output_dir=paths.output_dir, highlighter=highlighter
-        )
-        self._copy_static_assets(paths=paths, config=config)
+        if self._dry_run:
+            if highlighter:
+                self._detail(
+                    f"Dry run: would write syntax stylesheet to {paths.output_dir / 'syntax.css'}"
+                )
+            if os.path.isdir(paths.project_dir / config.static_dir):
+                self._detail(
+                    f"Dry run: would copy static assets from {paths.project_dir / config.static_dir}"
+                )
+        else:
+            self._write_syntax_stylesheet(
+                output_dir=paths.output_dir, highlighter=highlighter
+            )
+            self._copy_static_assets(paths=paths, config=config)
 
         return RenderSummary(
             total_files=total_files,
@@ -318,6 +349,9 @@ class BuildCommand(BaseCommand):
             template,
             context={"content": tuple(sorted_content), "tags": tag_map},
         )
+        if self._dry_run:
+            self._detail(f"Dry run: would render {filename}")
+            return TemplateRenderResult(built=True, cached=False)
         output_path = os.path.join(output_dir, filename)
         with open(output_path, "w") as f:
             f.write(rendered)
@@ -367,7 +401,7 @@ class BuildCommand(BaseCommand):
             output_mode=config.static_dir_output,
         )
         if static_output:
-            self._info(f"Copied static assets -> {static_output}")
+            self._info(f"Copied static assets to {static_output}")
 
     def _generate_feeds(
         self,
@@ -378,10 +412,14 @@ class BuildCommand(BaseCommand):
         if not config.feeds:
             return 0
 
-        self._info("Generating RSS feeds...")
+        self._info("Generating RSS feeds")
         generator = RssFeedGenerator(config=config)
         feed_count = 0
         for output_name, xml in generator.generate(collection):
+            if self._dry_run:
+                self._detail(f"Dry run: would write feed {output_name}")
+                feed_count += 1
+                continue
             output_path = os.path.join(output_dir, output_name)
             with open(output_path, "w") as f:
                 f.write(xml)
@@ -395,12 +433,18 @@ class BuildCommand(BaseCommand):
         parsing_time: float,
         total_time: float,
     ) -> None:
-        self._success("Build complete!")
-        self._success(f"Total files: {render_summary.total_files}")
-        self._success(f"Total components: {len(render_summary.component_names)}")
-        self._success(f"Built: {render_summary.built_files}")
-        self._success(f"Cached: {render_summary.cached_files}")
-        self._success(f"RSS feeds: {feed_count}")
-        self._success(f"Parsing time: {parsing_time:.3f}s")
-        self._success(f"Rendering time: {render_summary.rendering_time:.3f}s")
-        self._success(f"Total time: {total_time:.3f}s")
+        summary_label = "Dry run complete" if self._dry_run else "Build complete"
+        self._success(
+            f"{summary_label}: "
+            f"{render_summary.total_files} templates, "
+            f"{render_summary.built_files} built, "
+            f"{render_summary.cached_files} cached, "
+            f"{len(render_summary.component_names)} components, "
+            f"{feed_count} RSS feeds"
+        )
+        self._info(
+            "Timings: "
+            f"parse {parsing_time:.3f}s, "
+            f"render {render_summary.rendering_time:.3f}s, "
+            f"total {total_time:.3f}s"
+        )

--- a/pyssg/commands/init.py
+++ b/pyssg/commands/init.py
@@ -13,12 +13,22 @@ logger = logging.getLogger(__name__)
 
 
 class InitCommand(BaseCommand):
-    def __init__(self, folder_name: str) -> None:
+    def __init__(
+        self,
+        folder_name: str,
+        *,
+        verbose: bool = False,
+        dry_run: bool = False,
+    ) -> None:
+        super().__init__(verbose=verbose, dry_run=dry_run)
         self.folder_name = folder_name
 
     def _create_folder(self) -> bool:
         new_folder = Path.cwd() / self.folder_name
         if not os.path.exists(new_folder):
+            if self._dry_run:
+                self._info(f"Dry run: would create folder {new_folder}")
+                return True
             os.mkdir(new_folder)
             self._info(f"Created folder: {self.folder_name}")
             return True
@@ -28,6 +38,17 @@ class InitCommand(BaseCommand):
     def _init_structure(self, folder: Path) -> None:
         if os.path.isfile(folder / CONFIG_FILENAME):
             self._error("Configuration files already exist!")
+            return
+
+        if self._dry_run:
+            self._info(f"Dry run: would create project structure in {folder}")
+            self._detail(f"Would create: {folder / 'content'}")
+            self._detail(f"Would create: {folder / 'templates'}")
+            self._detail(f"Would create: {folder / 'components'}")
+            self._detail(f"Would create: {folder / 'output'}")
+            self._detail(f"Would copy: {folder / CONFIG_FILENAME}")
+            self._detail(f"Would create cache in: {folder}")
+            self._success(f"Dry run complete: would initialize structure in {folder}")
             return
 
         os.mkdir(folder / "content")

--- a/pyssg/commands/serve.py
+++ b/pyssg/commands/serve.py
@@ -9,7 +9,14 @@ from pyssg.modules.watcher import Watcher
 
 
 class ServeCommand(BaseCommand):
-    def __init__(self, port: int | None = None) -> None:
+    def __init__(
+        self,
+        port: int | None = None,
+        *,
+        verbose: bool = False,
+        dry_run: bool = False,
+    ) -> None:
+        super().__init__(verbose=verbose, dry_run=dry_run)
         self._port = port
 
     def execute(self) -> None:
@@ -18,13 +25,8 @@ class ServeCommand(BaseCommand):
         config = SiteConfig.load(project_dir)
         port = self._port if self._port is not None else config.server.port
 
-        self._info("Running initial build...")
+        self._info("Running initial build")
         self._rebuild()
-
-        server = Server(directory=project_dir / ProjectDirectory.OUTPUT, port=port)
-        server.start()
-        self._success(f"Serving on http://localhost:{port}")
-
         directories = [
             project_dir / ProjectDirectory.CONTENT,
             project_dir / ProjectDirectory.TEMPLATES,
@@ -33,27 +35,39 @@ class ServeCommand(BaseCommand):
         static_dir = project_dir / config.static_dir
         if static_dir.exists():
             directories.append(static_dir)
+        self._detail(
+            f"Watch directories: {', '.join(str(directory) for directory in directories)}"
+        )
+
+        if self._dry_run:
+            self._success(f"Dry run complete: would serve at http://localhost:{port}")
+            self._info("Dry run: watcher was not started")
+            return
+
+        server = Server(directory=project_dir / ProjectDirectory.OUTPUT, port=port)
+        server.start()
+        self._success(f"Serving at http://localhost:{port}")
 
         watcher = Watcher(
             directories=directories,
             on_change=self._rebuild,
         )
         watcher.start()
-        self._info("Watching for changes... (press Ctrl+C to stop)")
+        self._info("Watching for changes. Press Ctrl+C to stop")
 
         try:
             self._wait_forever()
         except KeyboardInterrupt:
-            self._info("Shutting down...")
+            self._info("Shutting down")
             server.stop()
             watcher.stop()
 
     def _rebuild(self) -> None:
         try:
-            build = BuildCommand()
+            build = BuildCommand(verbose=self._verbose, dry_run=self._dry_run)
             build.execute()
         except Exception as e:
-            self._error(f"Build failed: {e}")
+            self._error(f"Build failed during rebuild: {e}")
 
     def _wait_forever(self) -> None:
         while True:

--- a/pyssg/main.py
+++ b/pyssg/main.py
@@ -20,20 +20,41 @@ def callback() -> None:
 
 
 @app.command()
-def init(folder_name: str = typer.Argument(default=".")) -> None:
-    init_command = InitCommand(folder_name=folder_name)
+def init(
+    folder_name: str = typer.Argument(default="."),
+    verbose: bool = typer.Option(default=False, help="Show additional details."),
+    dry_run: bool = typer.Option(
+        default=False, help="Preview changes without writing files."
+    ),
+) -> None:
+    init_command = InitCommand(
+        folder_name=folder_name,
+        verbose=verbose,
+        dry_run=dry_run,
+    )
     init_command.execute()
 
 
 @app.command()
-def build() -> None:
-    build_command = BuildCommand()
+def build(
+    verbose: bool = typer.Option(default=False, help="Show additional details."),
+    dry_run: bool = typer.Option(
+        default=False, help="Preview changes without writing files."
+    ),
+) -> None:
+    build_command = BuildCommand(verbose=verbose, dry_run=dry_run)
     build_command.execute()
 
 
 @app.command()
-def serve(port: int | None = typer.Option(default=None)) -> None:
-    serve_command = ServeCommand(port=port)
+def serve(
+    port: int | None = typer.Option(default=None),
+    verbose: bool = typer.Option(default=False, help="Show additional details."),
+    dry_run: bool = typer.Option(
+        default=False, help="Preview startup without writing files or serving."
+    ),
+) -> None:
+    serve_command = ServeCommand(port=port, verbose=verbose, dry_run=dry_run)
     serve_command.execute()
 
 

--- a/tests/app/commands/test_base_command.py
+++ b/tests/app/commands/test_base_command.py
@@ -7,8 +7,8 @@ from pyssg.commands.base_command import BaseCommand
 TEST_PATH = "pyssg.commands.base_command"
 
 TERM_LENGTH = 40
-CONTENT_WIDTH = TERM_LENGTH - 1
-TEXT_WIDTH = CONTENT_WIDTH - 4  # 2-char padding on each side
+PREFIX = "[bold blue][INFO][/bold blue] "
+TEXT_WIDTH = TERM_LENGTH - len("INFO") - 4
 
 
 class ConcreteCommand(BaseCommand):
@@ -19,20 +19,14 @@ class ConcreteCommand(BaseCommand):
 class TestPrintBlock:
     @patch(f"{TEST_PATH}.rich_print")
     @patch(f"{TEST_PATH}.shutil")
-    def test_prints_border_and_message(self, mock_shutil, mock_rich_print):
+    def test_prints_status_line(self, mock_shutil, mock_rich_print):
         mock_shutil.get_terminal_size.return_value.columns = TERM_LENGTH
         command = ConcreteCommand()
 
         command._print_block("hello", color="blue")
 
-        spaces = " " * CONTENT_WIDTH
-        padding_line = f"[bold blue]┃[/bold blue]{spaces}"
-        padded = f"  {'hello':<{TEXT_WIDTH}}  "
-        message_line = f"[bold blue]┃{padded}[/bold blue]"
         assert mock_rich_print.call_args_list == [
-            call(padding_line),
-            call(message_line),
-            call(padding_line),
+            call(f"{PREFIX}hello"),
         ]
 
     @patch(f"{TEST_PATH}.rich_print")
@@ -44,20 +38,20 @@ class TestPrintBlock:
 
         command._print_block(long_message.strip(), color="blue")
 
-        # padding + at least 2 message lines + padding
-        assert mock_rich_print.call_count >= 4
+        assert mock_rich_print.call_count >= 2
+        assert mock_rich_print.call_args_list[0].args[0].startswith(PREFIX)
+        for wrapped_line in mock_rich_print.call_args_list[1:]:
+            assert wrapped_line.args[0].startswith(" " * len(PREFIX))
 
     @patch(f"{TEST_PATH}.rich_print")
     @patch(f"{TEST_PATH}.shutil")
-    def test_empty_message_prints_blank_line(self, mock_shutil, mock_rich_print):
+    def test_empty_message_prints_label_only(self, mock_shutil, mock_rich_print):
         mock_shutil.get_terminal_size.return_value.columns = TERM_LENGTH
         command = ConcreteCommand()
 
         command._print_block("", color="blue")
 
-        padded = f"  {'':<{TEXT_WIDTH}}  "
-        message_line = f"[bold blue]┃{padded}[/bold blue]"
-        assert mock_rich_print.call_args_list[1] == call(message_line)
+        assert mock_rich_print.call_args_list == [call(PREFIX.rstrip())]
 
 
 class TestInfo:
@@ -65,6 +59,18 @@ class TestInfo:
     def test_uses_blue(self, mock_print_block):
         ConcreteCommand()._info("hello")
         mock_print_block.assert_called_once_with("hello", color="blue")
+
+
+class TestDetail:
+    @patch.object(ConcreteCommand, "_info")
+    def test_skips_info_when_verbose_disabled(self, mock_info):
+        ConcreteCommand()._detail("hello")
+        mock_info.assert_not_called()
+
+    @patch.object(ConcreteCommand, "_info")
+    def test_uses_info_when_verbose_enabled(self, mock_info):
+        ConcreteCommand(verbose=True)._detail("hello")
+        mock_info.assert_called_once_with("hello")
 
 
 class TestSuccess:

--- a/tests/app/commands/test_build.py
+++ b/tests/app/commands/test_build.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from types import MappingProxyType
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from pyssg.commands.build import (
     BuildCommand,
@@ -348,7 +348,7 @@ def test_parse_markdown_configures_parser_and_returns_timing(
 
     assert parsed_collection is collection
     assert parsing_time >= 0
-    mock_info.assert_called_once_with("Parsing markdown files...")
+    mock_info.assert_called_once_with("Parsing markdown content")
     mock_parser_cls.assert_called_once_with(
         content_dir=Path("/project/content"),
         render_markdown=None,
@@ -485,6 +485,34 @@ def test_render_template_file_does_not_update_cache_for_dynamic_templates(
     cache.update.assert_not_called()
 
 
+def test_render_template_file_dry_run_does_not_write_output(tmp_path: Path) -> None:
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "index.html").write_text("<h1>Template</h1>", encoding="utf-8")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    engine = MagicMock()
+    engine.render.return_value = "<h1>Rendered</h1>"
+    cache = MagicMock()
+    cache.has_dynamic_constructs.return_value = False
+    cache.needs_rebuild.return_value = True
+    command = BuildCommand(dry_run=True)
+
+    result = command._render_template_file(
+        filename="index.html",
+        templates_dir=templates_dir,
+        output_dir=output_dir,
+        engine=engine,
+        sorted_content=[],
+        tag_map={},
+        cache=cache,
+    )
+
+    assert result == TemplateRenderResult(built=True, cached=False)
+    cache.update.assert_not_called()
+    assert not (output_dir / "index.html").exists()
+
+
 def test_render_template_files_counts_only_html_files(tmp_path: Path) -> None:
     templates_dir = tmp_path / "templates"
     templates_dir.mkdir()
@@ -619,7 +647,7 @@ def test_copy_static_assets_reports_destination(
 
     command._copy_static_assets(paths, _default_config())
 
-    mock_info.assert_called_once_with("Copied static assets -> output/static/")
+    mock_info.assert_called_once_with("Copied static assets to output/static/")
     assert (output_dir / "static" / "site.css").exists()
 
 
@@ -648,7 +676,7 @@ def test_generate_feeds_writes_each_feed_and_returns_count(
     )
 
     assert feed_count == 2
-    mock_info.assert_called_once_with("Generating RSS feeds...")
+    mock_info.assert_called_once_with("Generating RSS feeds")
     mock_generator_cls.assert_called_once_with(config=config)
     assert (output_dir / "feed.xml").read_text(encoding="utf-8") == "<rss />"
     assert (output_dir / "news.xml").read_text(encoding="utf-8") == "<rss />"
@@ -674,8 +702,40 @@ def test_generate_feeds_skips_generator_when_no_feeds_configured(
     mock_generator_cls.assert_not_called()
 
 
+@patch.object(BuildCommand, "_info")
+@patch(f"{TEST_PATH}.RssFeedGenerator")
+def test_generate_feeds_dry_run_counts_without_writing(
+    mock_generator_cls: MagicMock,
+    mock_info: MagicMock,
+    tmp_path: Path,
+) -> None:
+    config = _default_config(name="Example", url="https://example.com")
+    config.feeds = [FeedConfig(title="Main"), FeedConfig(title="News")]
+    collection = _make_collection(MarkdownContent(filename="post.md", html=""))
+    mock_generator_cls.return_value.generate.return_value = [
+        ("feed.xml", "<rss />"),
+        ("news.xml", "<rss />"),
+    ]
+    command = BuildCommand(dry_run=True)
+
+    feed_count = command._generate_feeds(
+        config=config,
+        output_dir=tmp_path,
+        collection=collection,
+    )
+
+    assert feed_count == 2
+    mock_info.assert_called_once_with("Generating RSS feeds")
+    assert not (tmp_path / "feed.xml").exists()
+    assert not (tmp_path / "news.xml").exists()
+
+
+@patch.object(BuildCommand, "_info")
 @patch.object(BuildCommand, "_success")
-def test_print_summary_reports_all_totals(mock_success: MagicMock) -> None:
+def test_print_summary_reports_compact_totals(
+    mock_success: MagicMock,
+    mock_info: MagicMock,
+) -> None:
     command = BuildCommand()
     render_summary = RenderSummary(
         total_files=3,
@@ -692,17 +752,12 @@ def test_print_summary_reports_all_totals(mock_success: MagicMock) -> None:
         total_time=0.4,
     )
 
-    assert mock_success.call_args_list == [
-        call("Build complete!"),
-        call("Total files: 3"),
-        call("Total components: 2"),
-        call("Built: 2"),
-        call("Cached: 1"),
-        call("RSS feeds: 4"),
-        call("Parsing time: 0.100s"),
-        call("Rendering time: 0.200s"),
-        call("Total time: 0.400s"),
-    ]
+    mock_success.assert_called_once_with(
+        "Build complete: 3 templates, 2 built, 1 cached, 2 components, 4 RSS feeds"
+    )
+    mock_info.assert_called_once_with(
+        "Timings: parse 0.100s, render 0.200s, total 0.400s"
+    )
 
 
 @patch(f"{TEST_PATH}.time.perf_counter")
@@ -772,3 +827,60 @@ def test_execute_orchestrates_build_steps_and_updates_context(
         "parsing_time": 0.25,
         "total_time": 2.0,
     }
+
+
+@patch(f"{TEST_PATH}.time.perf_counter")
+@patch(f"{TEST_PATH}.BuildScript")
+@patch(f"{TEST_PATH}.BuildCache")
+@patch(f"{TEST_PATH}.SiteConfig.load")
+@patch.object(BuildCommand, "_print_summary")
+@patch.object(BuildCommand, "_generate_feeds")
+@patch.object(BuildCommand, "_render_templates")
+@patch.object(BuildCommand, "_parse_markdown")
+@patch.object(BuildCommand, "_create_toc_generator")
+@patch.object(BuildCommand, "_create_highlighter")
+@patch.object(BuildCommand, "_build_paths")
+def test_execute_dry_run_skips_side_effect_hooks_and_cache_save(
+    mock_build_paths: MagicMock,
+    mock_create_highlighter: MagicMock,
+    mock_create_toc_generator: MagicMock,
+    mock_parse_markdown: MagicMock,
+    mock_render_templates: MagicMock,
+    mock_generate_feeds: MagicMock,
+    mock_print_summary: MagicMock,
+    mock_load_config: MagicMock,
+    mock_cache_cls: MagicMock,
+    mock_build_script_cls: MagicMock,
+    mock_perf_counter: MagicMock,
+) -> None:
+    paths = BuildPaths(
+        project_dir=Path("/project"),
+        templates_dir=Path("/project/templates"),
+        components_dir=Path("/project/components"),
+        output_dir=Path("/project/output"),
+    )
+    render_summary = RenderSummary(
+        total_files=1,
+        built_files=1,
+        cached_files=0,
+        component_names=[],
+        rendering_time=0.5,
+    )
+    config = _default_config(name="Example")
+    collection = _make_collection(MarkdownContent(filename="post.md", html="<p>Hi</p>"))
+    mock_build_paths.return_value = paths
+    mock_load_config.return_value = config
+    mock_parse_markdown.return_value = (collection, 0.25)
+    mock_render_templates.return_value = render_summary
+    mock_generate_feeds.return_value = 1
+    mock_perf_counter.side_effect = [10.0, 12.0]
+    command = BuildCommand(dry_run=True)
+
+    command.execute()
+
+    mock_build_script_cls.return_value.before_build.assert_not_called()
+    mock_build_script_cls.return_value.before_markdown_parsing.assert_not_called()
+    mock_build_script_cls.return_value.before_component_parsing.assert_not_called()
+    mock_build_script_cls.return_value.after_build.assert_not_called()
+    mock_cache_cls.return_value.save.assert_not_called()
+    mock_print_summary.assert_called_once()

--- a/tests/app/commands/test_init.py
+++ b/tests/app/commands/test_init.py
@@ -35,6 +35,24 @@ class TestCreateFolder:
         mock_warning.assert_called_once_with("Folder already exists: test_folder")
         mock_os.mkdir.assert_not_called()
 
+    @patch(f"{TEST_PATH}.Path")
+    @patch(f"{TEST_PATH}.os")
+    def test_dry_run_reports_folder_creation_without_creating(
+        self, mock_os, mock_path, tmp_path
+    ):
+        mock_path.cwd.return_value = tmp_path
+        command = InitCommand(folder_name="test_folder", dry_run=True)
+        mock_os.path.exists.return_value = False
+
+        with patch.object(command, "_info") as mock_info:
+            result = command._create_folder()
+
+        assert result is True
+        mock_info.assert_called_once_with(
+            f"Dry run: would create folder {tmp_path / 'test_folder'}"
+        )
+        mock_os.mkdir.assert_not_called()
+
 
 class TestInitStructure:
     @patch(f"{TEST_PATH}.BuildCache")
@@ -90,6 +108,31 @@ class TestInitStructure:
 
         mock_error.assert_called_once_with("Configuration files already exist!")
         mock_os.mkdir.assert_not_called()
+
+    @patch(f"{TEST_PATH}.BuildCache")
+    @patch(f"{TEST_PATH}.shutil")
+    @patch(f"{TEST_PATH}.os")
+    def test_dry_run_reports_actions_without_creating_files(
+        self, mock_os, mock_shutil, mock_cache_cls, tmp_path
+    ):
+        command = InitCommand(folder_name=".", dry_run=True, verbose=True)
+        mock_os.path.isfile.return_value = False
+
+        with (
+            patch.object(command, "_info") as mock_info,
+            patch.object(command, "_success") as mock_success,
+        ):
+            command._init_structure(folder=tmp_path)
+
+        mock_os.mkdir.assert_not_called()
+        mock_shutil.copy2.assert_not_called()
+        mock_cache_cls.create.assert_not_called()
+        mock_info.assert_any_call(
+            f"Dry run: would create project structure in {tmp_path}"
+        )
+        mock_success.assert_called_once_with(
+            f"Dry run complete: would initialize structure in {tmp_path}"
+        )
 
 
 class TestExecute:

--- a/tests/app/commands/test_serve.py
+++ b/tests/app/commands/test_serve.py
@@ -23,6 +23,10 @@ class TestInit:
         command = ServeCommand()
         assert command._port is None
 
+    def test_stores_dry_run(self):
+        command = ServeCommand(dry_run=True)
+        assert command._dry_run is True
+
 
 class TestExecute:
     @patch(f"{TEST_PATH}.SiteConfig")
@@ -198,6 +202,30 @@ class TestExecute:
 
         mock_server.stop.assert_called_once()
         mock_watcher.stop.assert_called_once()
+
+    @patch(f"{TEST_PATH}.SiteConfig")
+    @patch(f"{TEST_PATH}.Watcher")
+    @patch(f"{TEST_PATH}.Server")
+    @patch(f"{TEST_PATH}.BuildCommand")
+    @patch(f"{TEST_PATH}.Path")
+    def test_dry_run_does_not_start_server_or_watcher(
+        self,
+        mock_path,
+        mock_build_cls,
+        mock_server_cls,
+        mock_watcher_cls,
+        mock_config_cls,
+    ):
+        mock_path.cwd.return_value = Path("/project")
+        mock_config_cls.load.return_value = _default_config()
+        command = ServeCommand(port=8000, verbose=True, dry_run=True)
+
+        command.execute()
+
+        mock_build_cls.assert_called_once_with(verbose=True, dry_run=True)
+        mock_build_cls.return_value.execute.assert_called_once()
+        mock_server_cls.assert_not_called()
+        mock_watcher_cls.assert_not_called()
 
 
 class TestRebuild:

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from pyssg.main import app
+
+TEST_PATH = "pyssg.main"
+
+runner = CliRunner()
+
+
+@patch(f"{TEST_PATH}.BuildCommand")
+def test_build_passes_verbose_and_dry_run_to_command(mock_build_cls) -> None:
+    result = runner.invoke(app, ["build", "--verbose", "--dry-run"])
+
+    assert result.exit_code == 0
+    mock_build_cls.assert_called_once_with(verbose=True, dry_run=True)
+    mock_build_cls.return_value.execute.assert_called_once_with()
+
+
+@patch(f"{TEST_PATH}.InitCommand")
+def test_init_passes_verbose_and_dry_run_to_command(mock_init_cls) -> None:
+    result = runner.invoke(app, ["init", "demo", "--verbose", "--dry-run"])
+
+    assert result.exit_code == 0
+    mock_init_cls.assert_called_once_with(
+        folder_name="demo",
+        verbose=True,
+        dry_run=True,
+    )
+    mock_init_cls.return_value.execute.assert_called_once_with()
+
+
+@patch(f"{TEST_PATH}.ServeCommand")
+def test_serve_passes_port_verbose_and_dry_run_to_command(mock_serve_cls) -> None:
+    result = runner.invoke(app, ["serve", "--port", "9000", "--verbose", "--dry-run"])
+
+    assert result.exit_code == 0
+    mock_serve_cls.assert_called_once_with(port=9000, verbose=True, dry_run=True)
+    mock_serve_cls.return_value.execute.assert_called_once_with()


### PR DESCRIPTION
This pull request adds dry-run and verbose command-line options to all CLI commands (init, build, serve) and refactors the output system to support these modes more effectively.

Key changes:

BaseCommand has been extended with verbose and dry-run flags, initialized through the constructor. The _print_block method has been refactored to use a status prefix format ([INFO], [DONE], [WARN], [FAIL]) instead of bordered blocks, providing cleaner inline output. A new _detail method has been added to conditionally print additional information when verbose mode is enabled.

BuildCommand now respects dry-run mode by skipping all file writes, cache updates, and build hooks while still performing analysis and reporting what would be done. Verbose mode provides detailed information about configuration, discovered components, and template rendering decisions. The build summary output has been consolidated into a single compact line.

InitCommand has been updated to support dry-run mode, showing what would be created without actually creating files or directories.

ServeCommand has been updated to support dry-run mode, which runs the initial build and reports what would be served without starting the server or file watcher.

The main CLI module now exposes --verbose and --dry-run options for all commands, with appropriate help text for each.

All existing tests have been updated for the new output format, and comprehensive new tests have been added to verify dry-run behavior and verbose output in all commands.