### PR TITLE
Add py-ssg new command and content-generated pages with template helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Templates are Jinja2 HTML files in the `templates/` directory.
 - Standard page templates such as `index.html` and `about.html` are rendered and written to `output/` with the same filename.
 - Render-only templates ending in `*.tmpl.html` are available as template source files, but are never copied to or rendered directly into `output/`.
 - The `*.tmpl.html` rule also applies inside nested directories under `templates/`.
+- If a frontmatter `template` points at a normal `.html` file instead of `*.tmpl.html`, py-ssg warns because that file will also render as its own standalone page.
 
 ### Template Context
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Standard Jinja2 features are fully supported: `{% for %}`, `{% if %}`, `{% macro
 
 ## Components
 
-Components are reusable HTML snippets stored as `.html` files in the `components/` directory. They use a self-closing XML-like tag syntax and are automatically discovered at build time.
+Components are reusable HTML snippets stored as `.html` files in the `components/` directory. They are automatically discovered at build time.
 
 ### Creating a Component
 
@@ -304,7 +304,7 @@ Create a file in `components/` — the filename (without `.html`) becomes the ta
 
 ### Using Components
 
-Use self-closing tags in your templates. Attributes are passed as Jinja2 variables to the component:
+Components support both self-closing tags and open/close tags with child content. Attributes are passed as Jinja2 variables to the component.
 
 ```html
 <Navbar homeClass="active" aboutClass="" />
@@ -319,13 +319,28 @@ Renders to:
 </nav>
 ```
 
+When a component uses open/close tags, the inner HTML is available inside the component template as `{{ children }}`:
+
+```html
+<Card>
+  <p>Hello</p>
+</Card>
+```
+
+**`components/Card.html`**
+```html
+<div class="card">
+  {{ children }}
+</div>
+```
+
 ### Component Rules
 
-- Components **must** use self-closing syntax: `<Name />` or `<Name attr="value" />`
+- Components support self-closing syntax such as `<Name />` and open/close syntax such as `<Card>...</Card>`
 - Component filenames are **case-sensitive** and must match the tag name exactly
 - Components can contain full Jinja2 syntax (conditionals, loops, etc.)
 - Components can nest other components, up to **10 levels deep**
-- Components **do not** support child content (no open/close tags) — they are always self-closing
+- Child content is exposed to the component template through `{{ children }}`
 - Unknown tags are left untouched in the output
 
 ### Example: Conditional Component

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Your site is now live at `http://localhost:8000`.
 
 ## Commands
 
-### `py-ssg init [folder_name]`
+### `py-ssg init [folder_name] [--verbose] [--dry-run]`
 
 Scaffolds a new project. If `folder_name` is omitted, initializes in the current directory.
 
@@ -72,7 +72,13 @@ my-blog/
 └── py-ssg.toml     # Configuration file
 ```
 
-### `py-ssg build`
+Notes:
+
+- If the target folder already exists, initialization stops with a warning.
+- If `py-ssg.toml` already exists in the target, initialization stops and does not overwrite the project.
+- `--dry-run` prints the planned filesystem changes without creating files or folders.
+
+### `py-ssg build [--verbose] [--dry-run]`
 
 Builds the site. Reads markdown from `content/`, renders templates from `templates/`, resolves components from `components/`, and writes the result to `output/`.
 
@@ -82,9 +88,15 @@ The build reports:
 - RSS feeds generated
 - Parsing, rendering, and total time
 
-### `py-ssg serve [--port PORT]`
+Behavior notes:
 
-Runs an initial build, starts a local HTTP server, and watches for changes. Automatically rebuilds when files in `content/`, `templates/`, or `components/` change.
+- `--dry-run` skips build hooks and does not write output files, feeds, cache updates, or copied assets.
+- Markdown parsing still runs during `--dry-run`, so you can preview what would build.
+- Static assets are copied after template rendering, so colliding static files win.
+
+### `py-ssg serve [--port PORT] [--verbose] [--dry-run]`
+
+Runs an initial build, starts a local HTTP server, and watches for changes. Automatically rebuilds when files in `content/`, `templates/`, `components/`, or the configured static directory change.
 
 ```bash
 py-ssg serve              # Default port 8000
@@ -93,7 +105,12 @@ py-ssg serve --port 3000  # Custom port
 
 Press `Ctrl+C` for graceful shutdown.
 
-### `py-ssg new [--sub-folder SUB_FOLDER] "Post Title"`
+Behavior notes:
+
+- If `--port` is omitted, py-ssg uses `py-ssg.server.port` from config.
+- `--dry-run` performs the initial build preview and prints the URL it would serve, but does not start the server or watcher.
+
+### `py-ssg new [--sub-folder SUB_FOLDER] [--verbose] [--dry-run] "Post Title"`
 
 Creates a new markdown file inside `content/` with starter frontmatter.
 
@@ -115,6 +132,14 @@ title: "Post Title"
 timestamp: "2025-01-15"
 ---
 ```
+
+Behavior notes:
+
+- Filenames are generated from the title, lowercased and normalized with underscores. For example, `"Hello World"` becomes `hello_world.md`.
+- `--sub-folder blog/2025` creates nested folders as needed under `content/`.
+- If `--sub-folder` is omitted, py-ssg uses `new_content_subfolder` from config.
+- If the target file already exists, the command stops with a warning.
+- `--dry-run` prints the target path without writing the file.
 
 ## Project Structure
 
@@ -240,6 +265,7 @@ author_url: https://example.com
 | `summary` | string | Optional short summary |
 | `subtitle` | string | Optional subtitle |
 | `draft` | boolean | Optional draft flag |
+| `template` | string | Optional content page template path, usually a `*.tmpl.html` file under `templates/` |
 
 **Custom fields:** Any additional YAML keys beyond the built-in fields become accessible via `post.custom_fields`. For example, adding `series: python-notes` and `reading_time: 4` makes them available as `post.custom_fields.series` and `post.custom_fields.reading_time`.
 
@@ -273,11 +299,42 @@ Content routes are derived from the markdown filename relative to `content/`.
 - `content/blog/hello-world.md` becomes `post.url == "/blog/hello-world/"`
 - Content pages generated from frontmatter templates and RSS feed links both use this same canonical route
 
+### Content-Generated Pages
+
+Markdown files can generate their own standalone output pages without `pyssg_build.py` by setting `template` in frontmatter:
+
+```yaml
+---
+title: Hello World
+template: blog/post.tmpl.html
+---
+```
+
+With `content/blog/hello-world.md`, py-ssg renders `templates/blog/post.tmpl.html` and writes:
+
+```text
+output/blog/hello-world/index.html
+```
+
+These content-page templates receive:
+
+- `site`
+- `content`
+- `tags`
+- `post`
+
+Quirks:
+
+- Content-page outputs always follow the canonical route from `post.url`.
+- Content-page rendering is currently not template-cached; these pages rebuild every time.
+- If `template` points to a normal `.html` page template instead of `*.tmpl.html`, py-ssg warns because that template will also render as its own standalone page.
+
 ## Templates
 
 Templates are Jinja2 HTML files in the `templates/` directory.
 
 - Standard page templates such as `index.html` and `about.html` are rendered and written to `output/` with the same filename.
+- Nested page templates such as `templates/blog/index.html` are rendered by default to matching nested output paths like `output/blog/index.html`.
 - Render-only templates ending in `*.tmpl.html` are available as template source files, but are never copied to or rendered directly into `output/`.
 - The `*.tmpl.html` rule also applies inside nested directories under `templates/`.
 - If a frontmatter `template` points at a normal `.html` file instead of `*.tmpl.html`, py-ssg warns because that file will also render as its own standalone page.
@@ -290,6 +347,7 @@ All templates receive:
 |----------|-------------|
 | `site` | Site configuration object (`site.name`, `site.url`, `site.description`, `site.authors`, `site.feeds`) |
 | `content` | List of all `MarkdownContent` objects, sorted by `site.content_sort` (default: newest `timestamp` first, undated posts last) |
+| `tags` | Mapping of tag name to tuple of matching content items |
 
 ### Built-in Helpers
 
@@ -340,6 +398,10 @@ Templates also have these built-in globals and filters:
 
 Standard Jinja2 features are fully supported: `{% for %}`, `{% if %}`, `{% macro %}`, `{{ variable }}`, filters, etc.
 
+Template note:
+
+- Jinja autoescaping is disabled. Rendered markdown and component output are inserted as plain HTML, so escaping and trust boundaries are your responsibility.
+
 ## Components
 
 Components are reusable HTML snippets stored as `.html` files in the `components/` directory. They are automatically discovered at build time.
@@ -388,6 +450,8 @@ When a component uses open/close tags, the inner HTML is available inside the co
 </div>
 ```
 
+Nested component directories are also supported. A file such as `components/blog/Card.html` is available as `<blog.Card />`.
+
 ### Component Rules
 
 - Components support self-closing syntax such as `<Name />` and open/close syntax such as `<Card>...</Card>`
@@ -395,6 +459,9 @@ When a component uses open/close tags, the inner HTML is available inside the co
 - Components can contain full Jinja2 syntax (conditionals, loops, etc.)
 - Components can nest other components, up to **10 levels deep**
 - Child content is exposed to the component template through `{{ children }}`
+- Components inherit the parent template context, including `site`, `content`, `tags`, `post`, and any other variables already in scope
+- Component attributes override parent context variables with the same name
+- Attribute values are parsed as literal strings from the rendered HTML; quoted HTML-rich values are supported
 - Unknown tags are left untouched in the output
 
 ### Example: Conditional Component
@@ -476,6 +543,11 @@ tags = ["python"]
 
 Feed items include title, link (derived from `post.url`), description (full HTML), publication date (RFC 2822), and author. Items are sorted newest-first. When `tags` is specified, only posts with at least one matching tag are included.
 
+Notes:
+
+- Feed links and template-facing URLs use the same canonical route logic.
+- If `site.url` is empty, feed links become relative-looking values rooted at `/`.
+
 ## Build Hooks
 
 Create a `pyssg_build.py` file in your project root to hook into the build pipeline. Define any of these functions:
@@ -521,13 +593,26 @@ The `context` argument (`BuildContext`) provides:
 | `context.output_dir` | `Path` | Path to `output/` |
 | `context.content` | `MarkdownCollection` | Parsed content (`None` before `before_component_parsing`) |
 
-See `pyssg_build.example.py` in the repository for a complete example.
+See [pyssg_build.example.py](/Users/lucasqueiroz/Documents/projects/freeoss-space/py-ssg/pyssg_build.example.py:1) for a complete example.
 
 ## Build Caching
 
-When `cache = true` (default), py-ssg tracks SHA256 hashes of template files and skips rendering unchanged templates. Templates containing dynamic Jinja2 constructs (`for`, `if`, `macro`, `callblock`) are always rebuilt regardless of cache state.
+When `cache = true` (default), py-ssg stores cache data in `.pyssg_cache.json`.
 
-Cache is stored in `.pyssg_cache.json` at the project root.
+What is cached:
+
+- Parsed markdown content, keyed by the raw file contents plus syntax and TOC configuration
+- Static page templates whose source text has not changed
+
+What is not cached:
+
+- Templates containing dynamic Jinja2 constructs such as `for`, `if`, `macro`, or `callblock`
+- Content-generated pages from frontmatter `template`
+
+Notes:
+
+- Disabling cache with `cache = false` turns off both template and markdown-content cache usage.
+- Cache keys are based on source content, not dependency tracking between templates and content. If a static template reads `content`, the template cache still only considers the template file itself.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Place `.md` files in the `content/` directory. Each file uses YAML frontmatter f
 ---
 title: My Post Title
 timestamp: "2025-01-15"
+# `date` is also accepted as an alias for `timestamp`
 tags:
   - python
   - tutorial
@@ -205,7 +206,7 @@ author_url: https://example.com
 | Field | Type | Description |
 |-------|------|-------------|
 | `title` | string | Post title |
-| `timestamp` | string | Publication date (ISO format) |
+| `timestamp` | string | Publication date (ISO format). `date` is accepted as an alias |
 | `tags` | list | List of tag strings |
 | `author` | string | Author name |
 | `author_email` | string | Author email |
@@ -223,7 +224,7 @@ Each markdown file becomes a `MarkdownContent` object available in templates:
 | `post.filename` | Path relative to `content/` (e.g., `hello-world.md` or `blog/2025/hello-world.md`) |
 | `post.html` | Rendered HTML content |
 | `post.title` | Title from frontmatter |
-| `post.timestamp` | Timestamp string from frontmatter |
+| `post.timestamp` | Timestamp string from frontmatter (`date` aliases to this field) |
 | `post.tags` | List of tag strings |
 | `post.author.name` | Author name |
 | `post.author.email` | Author email |

--- a/README.md
+++ b/README.md
@@ -93,6 +93,29 @@ py-ssg serve --port 3000  # Custom port
 
 Press `Ctrl+C` for graceful shutdown.
 
+### `py-ssg new [--sub-folder SUB_FOLDER] "Post Title"`
+
+Creates a new markdown file inside `content/` with starter frontmatter.
+
+```bash
+py-ssg new "Post Title"
+py-ssg new --sub-folder blog "Post Title"
+```
+
+Examples:
+
+- `py-ssg new "Post Title"` creates `content/post_title.md`
+- `py-ssg new --sub-folder blog "Post Title"` creates `content/blog/post_title.md`
+
+The generated file includes:
+
+```yaml
+---
+title: "Post Title"
+timestamp: "2025-01-15"
+---
+```
+
 ## Project Structure
 
 ```
@@ -136,6 +159,7 @@ cache = true                    # Enable incremental build caching
 static_dir = "static"           # Source directory for copied assets
 static_dir_output = "static"    # "static" -> output/static, "root" -> output/
 content_sort = "date_desc"      # "date_desc", "date_asc", "filename", or "none"
+new_content_subfolder = ""      # Default sub-folder for `py-ssg new`
 
 [py-ssg.server]
 port = 8000                     # Dev server port

--- a/README.md
+++ b/README.md
@@ -249,6 +249,18 @@ All templates receive:
 | `site` | Site configuration object (`site.name`, `site.url`, `site.description`, `site.authors`, `site.feeds`) |
 | `content` | List of all `MarkdownContent` objects, sorted by `site.content_sort` (default: newest `timestamp` first, undated posts last) |
 
+### Built-in Helpers
+
+Templates also have these built-in globals and filters:
+
+| Helper | Type | Description |
+|--------|------|-------------|
+| `post_url(post)` | global | Returns the canonical URL for a content item, such as `/blog/hello-world/` |
+| `is_blog_post(post)` | global | Returns `true` when the content file lives under `content/blog/` |
+| `slug` | filter | Slugifies text by lowercasing it, removing special characters, and replacing spaces with hyphens |
+| `date_format` | filter | Formats ISO date or datetime strings with `strftime` syntax, for example `{{ post.timestamp\|date_format('%Y-%m-%d') }}` |
+| `excerpt` | filter | Strips HTML, normalizes whitespace, and truncates text with `...` |
+
 ### Example Template
 
 ```html

--- a/README.md
+++ b/README.md
@@ -241,6 +241,14 @@ Each markdown file becomes a `MarkdownContent` object available in templates:
 | `post.custom_fields` | Namespace with any extra frontmatter fields |
 | `post.toc` | Generated table of contents HTML (if enabled) |
 
+### Content Routing
+
+Content routes are derived from the markdown filename relative to `content/`.
+
+- `content/post.md` becomes `post.url == "/post/"`
+- `content/blog/hello-world.md` becomes `post.url == "/blog/hello-world/"`
+- Content pages generated from frontmatter templates and RSS feed links both use this same canonical route
+
 ## Templates
 
 Templates are Jinja2 HTML files in the `templates/` directory.
@@ -441,7 +449,7 @@ output = "python.xml"
 tags = ["python"]
 ```
 
-Feed items include title, link (derived from filename slug), description (full HTML), publication date (RFC 2822), and author. Items are sorted newest-first. When `tags` is specified, only posts with at least one matching tag are included.
+Feed items include title, link (derived from `post.url`), description (full HTML), publication date (RFC 2822), and author. Items are sorted newest-first. When `tags` is specified, only posts with at least one matching tag are included.
 
 ## Build Hooks
 

--- a/README.md
+++ b/README.md
@@ -212,8 +212,12 @@ author_url: https://example.com
 | `author_email` | string | Author email |
 | `author_avatar` | string | Author avatar URL |
 | `author_url` | string | Author website URL |
+| `slug` | string | Optional slug metadata |
+| `summary` | string | Optional short summary |
+| `subtitle` | string | Optional subtitle |
+| `draft` | boolean | Optional draft flag |
 
-**Custom fields:** Any additional YAML keys become accessible via `post.custom_fields`. For example, adding `slug: my-custom-slug` and `draft: true` to frontmatter makes them available as `post.custom_fields.slug` and `post.custom_fields.draft`.
+**Custom fields:** Any additional YAML keys beyond the built-in fields become accessible via `post.custom_fields`. For example, adding `series: python-notes` and `reading_time: 4` makes them available as `post.custom_fields.series` and `post.custom_fields.reading_time`.
 
 ### Parsed Content Object
 
@@ -225,6 +229,10 @@ Each markdown file becomes a `MarkdownContent` object available in templates:
 | `post.html` | Rendered HTML content |
 | `post.title` | Title from frontmatter |
 | `post.timestamp` | Timestamp string from frontmatter (`date` aliases to this field) |
+| `post.slug` | Built-in slug field |
+| `post.summary` | Built-in summary field |
+| `post.subtitle` | Built-in subtitle field |
+| `post.draft` | Built-in draft flag |
 | `post.tags` | List of tag strings |
 | `post.author.name` | Author name |
 | `post.author.email` | Author email |

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ my-blog/
 ├── content/            # Markdown files with YAML frontmatter
 │   ├── hello-world.md
 │   └── about.md
-├── templates/          # Jinja2 HTML templates (each .html file → output)
+├── templates/          # Jinja2 HTML templates
 │   ├── index.html
 │   └── about.html
 ├── components/         # Reusable HTML components
@@ -234,7 +234,11 @@ Each markdown file becomes a `MarkdownContent` object available in templates:
 
 ## Templates
 
-Templates are Jinja2 HTML files in the `templates/` directory. Every `.html` file in this directory is rendered and written to `output/` with the same filename.
+Templates are Jinja2 HTML files in the `templates/` directory.
+
+- Standard page templates such as `index.html` and `about.html` are rendered and written to `output/` with the same filename.
+- Render-only templates ending in `*.tmpl.html` are available as template source files, but are never copied to or rendered directly into `output/`.
+- The `*.tmpl.html` rule also applies inside nested directories under `templates/`.
 
 ### Template Context
 

--- a/pyssg/commands/build.py
+++ b/pyssg/commands/build.py
@@ -49,6 +49,17 @@ def _is_output_template(filename: str) -> bool:
     return filename.endswith(".html") and not _is_render_only_template(filename)
 
 
+def _content_template_name(content: MarkdownContent) -> str | None:
+    template_name = getattr(content.custom_fields, "template", None)
+    if not isinstance(template_name, str) or template_name == "":
+        return None
+    return template_name
+
+
+def _content_output_filename(content: MarkdownContent) -> str:
+    return f"{content.filename.removesuffix('.md')}/index.html"
+
+
 class ProjectDirectory(StrEnum):
     CONTENT = "content"
     TEMPLATES = "templates"
@@ -271,6 +282,18 @@ class BuildCommand(BaseCommand):
             cache=cache,
             content_sort=config.content_sort,
         )
+        (
+            content_total_files,
+            content_built_files,
+            content_cached_files,
+        ) = self._render_content_pages(
+            templates_dir=paths.templates_dir,
+            output_dir=paths.output_dir,
+            engine=engine,
+            collection=collection,
+            cache=cache,
+            content_sort=config.content_sort,
+        )
         if self._dry_run:
             if highlighter:
                 self._detail(
@@ -287,9 +310,9 @@ class BuildCommand(BaseCommand):
             self._copy_static_assets(paths=paths, config=config)
 
         return RenderSummary(
-            total_files=total_files,
-            built_files=built_files,
-            cached_files=cached_files,
+            total_files=total_files + content_total_files,
+            built_files=built_files + content_built_files,
+            cached_files=cached_files + content_cached_files,
             component_names=component_names,
             rendering_time=time.perf_counter() - rendering_start,
         )
@@ -347,6 +370,80 @@ class BuildCommand(BaseCommand):
                 built_files += 1
 
         return total_files, built_files, cached_files
+
+    def _render_content_pages(
+        self,
+        templates_dir: Path,
+        output_dir: Path,
+        engine: HtmlTemplateEngine,
+        collection: MarkdownCollection,
+        cache: BuildCache,
+        content_sort: str,
+    ) -> tuple[int, int, int]:
+        total_files = 0
+        built_files = 0
+        cached_files = 0
+        sorted_content = self._sort_content(collection, content_sort)
+        tag_map = self._build_tag_map(sorted_content)
+
+        for post in sorted_content:
+            template_name = _content_template_name(post)
+            if template_name is None:
+                continue
+
+            total_files += 1
+            result = self._render_content_page(
+                template_name=template_name,
+                output_filename=_content_output_filename(post),
+                templates_dir=templates_dir,
+                output_dir=output_dir,
+                engine=engine,
+                sorted_content=sorted_content,
+                tag_map=tag_map,
+                post=post,
+                cache=cache,
+            )
+            if result.cached:
+                cached_files += 1
+            if result.built:
+                built_files += 1
+
+        return total_files, built_files, cached_files
+
+    def _render_content_page(
+        self,
+        template_name: str,
+        output_filename: str,
+        templates_dir: Path,
+        output_dir: Path,
+        engine: HtmlTemplateEngine,
+        sorted_content: list[MarkdownContent],
+        tag_map: TagMap,
+        post: MarkdownContent,
+        cache: BuildCache,
+    ) -> TemplateRenderResult:
+        del cache
+        filepath = os.path.join(templates_dir, template_name)
+        with open(filepath) as f:
+            template = f.read()
+
+        rendered = engine.render(
+            template,
+            context={
+                "content": tuple(sorted_content),
+                "tags": tag_map,
+                "post": post,
+            },
+        )
+        if self._dry_run:
+            self._detail(f"Dry run: would render {output_filename}")
+            return TemplateRenderResult(built=True, cached=False)
+        output_path = os.path.join(output_dir, output_filename)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w") as f:
+            f.write(rendered)
+
+        return TemplateRenderResult(built=True, cached=False)
 
     def _render_template_file(
         self,

--- a/pyssg/commands/build.py
+++ b/pyssg/commands/build.py
@@ -386,6 +386,7 @@ class BuildCommand(BaseCommand):
         cached_files = 0
         sorted_content = self._sort_content(collection, content_sort)
         tag_map = self._build_tag_map(sorted_content)
+        self._warn_for_non_render_only_content_templates(sorted_content)
 
         for post in sorted_content:
             template_name = _content_template_name(post)
@@ -410,6 +411,26 @@ class BuildCommand(BaseCommand):
                 built_files += 1
 
         return total_files, built_files, cached_files
+
+    def _warn_for_non_render_only_content_templates(
+        self, sorted_content: list[MarkdownContent]
+    ) -> None:
+        warned_templates: set[str] = set()
+        for post in sorted_content:
+            template_name = _content_template_name(post)
+            if template_name is None:
+                continue
+            if _is_render_only_template(template_name):
+                continue
+            if template_name in warned_templates:
+                continue
+            warned_templates.add(template_name)
+            self._warning(
+                f"Content template {template_name} is not render-only and will "
+                "also be rendered as a standalone page. Rename it to "
+                f"{template_name.removesuffix('.html')}.tmpl.html if it should "
+                "only be used through frontmatter."
+            )
 
     def _render_content_page(
         self,

--- a/pyssg/commands/build.py
+++ b/pyssg/commands/build.py
@@ -45,6 +45,10 @@ def _is_render_only_template(filename: str) -> bool:
     return filename.endswith(".tmpl.html")
 
 
+def _is_output_template(filename: str) -> bool:
+    return filename.endswith(".html") and not _is_render_only_template(filename)
+
+
 class ProjectDirectory(StrEnum):
     CONTENT = "content"
     TEMPLATES = "templates"
@@ -301,8 +305,15 @@ class BuildCommand(BaseCommand):
             shutil.copytree(
                 entry_path,
                 dest,
-                ignore=shutil.ignore_patterns("*.tmpl.html"),
+                ignore=shutil.ignore_patterns("*.html"),
             )
+
+    def _iter_template_filenames(self, templates_dir: Path) -> list[str]:
+        return sorted(
+            str(path.relative_to(templates_dir).as_posix())
+            for path in templates_dir.rglob("*.html")
+            if _is_output_template(path.name)
+        )
 
     def _render_template_files(
         self,
@@ -319,12 +330,7 @@ class BuildCommand(BaseCommand):
         sorted_content = self._sort_content(collection, content_sort)
         tag_map = self._build_tag_map(sorted_content)
 
-        for filename in os.listdir(templates_dir):
-            if not filename.endswith(".html"):
-                continue
-            if _is_render_only_template(filename):
-                continue
-
+        for filename in self._iter_template_filenames(templates_dir):
             total_files += 1
             result = self._render_template_file(
                 filename=filename,
@@ -368,6 +374,7 @@ class BuildCommand(BaseCommand):
             self._detail(f"Dry run: would render {filename}")
             return TemplateRenderResult(built=True, cached=False)
         output_path = os.path.join(output_dir, filename)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
         with open(output_path, "w") as f:
             f.write(rendered)
 

--- a/pyssg/commands/build.py
+++ b/pyssg/commands/build.py
@@ -18,6 +18,7 @@ from pyssg.modules.markdown import (
     MarkdownContent,
     MarkdownParser,
     TocGenerator,
+    content_url_from_filename,
 )
 from pyssg.modules.rss import RssFeedGenerator
 from pyssg.modules.syntax import SyntaxHighlighter
@@ -57,7 +58,7 @@ def _content_template_name(content: MarkdownContent) -> str | None:
 
 
 def _content_output_filename(content: MarkdownContent) -> str:
-    return f"{content.filename.removesuffix('.md')}/index.html"
+    return f"{content_url_from_filename(content.filename).strip('/')}/index.html"
 
 
 class ProjectDirectory(StrEnum):

--- a/pyssg/commands/build.py
+++ b/pyssg/commands/build.py
@@ -41,6 +41,10 @@ def _discover_components(components_dir: Path) -> list[str]:
     return names
 
 
+def _is_render_only_template(filename: str) -> bool:
+    return filename.endswith(".tmpl.html")
+
+
 class ProjectDirectory(StrEnum):
     CONTENT = "content"
     TEMPLATES = "templates"
@@ -294,7 +298,11 @@ class BuildCommand(BaseCommand):
             dest = os.path.join(paths.output_dir, entry)
             if os.path.exists(dest):
                 shutil.rmtree(dest)
-            shutil.copytree(entry_path, dest)
+            shutil.copytree(
+                entry_path,
+                dest,
+                ignore=shutil.ignore_patterns("*.tmpl.html"),
+            )
 
     def _render_template_files(
         self,
@@ -313,6 +321,8 @@ class BuildCommand(BaseCommand):
 
         for filename in os.listdir(templates_dir):
             if not filename.endswith(".html"):
+                continue
+            if _is_render_only_template(filename):
                 continue
 
             total_files += 1

--- a/pyssg/commands/new.py
+++ b/pyssg/commands/new.py
@@ -45,12 +45,7 @@ class NewCommand(BaseCommand):
 
     def _file_contents(self) -> str:
         timestamp = datetime.now().date().isoformat()
-        return (
-            "---\n"
-            f'title: "{self.title}"\n'
-            f'timestamp: "{timestamp}"\n'
-            "---\n\n"
-        )
+        return f'---\ntitle: "{self.title}"\ntimestamp: "{timestamp}"\n---\n\n'
 
     def execute(self) -> None:
         project_dir = Path.cwd()

--- a/pyssg/commands/new.py
+++ b/pyssg/commands/new.py
@@ -1,0 +1,70 @@
+import re
+from datetime import datetime
+from pathlib import Path
+
+from pyssg.commands.base_command import BaseCommand
+from pyssg.modules.config import SiteConfig
+
+_FILENAME_STRIP_RE = re.compile(r"[^\w\s-]")
+_FILENAME_SPACE_RE = re.compile(r"[\s-]+")
+
+
+def _slugify_filename(title: str) -> str:
+    lowered = title.strip().lower()
+    stripped = _FILENAME_STRIP_RE.sub("", lowered)
+    normalized = _FILENAME_SPACE_RE.sub("_", stripped).strip("_")
+    return normalized or "untitled"
+
+
+class NewCommand(BaseCommand):
+    def __init__(
+        self,
+        title: str,
+        sub_folder: str | None = None,
+        *,
+        verbose: bool = False,
+        dry_run: bool = False,
+    ) -> None:
+        super().__init__(verbose=verbose, dry_run=dry_run)
+        self.title = title
+        self.sub_folder = sub_folder
+
+    def _resolve_sub_folder(self, config: SiteConfig) -> str:
+        if self.sub_folder is not None:
+            return self.sub_folder.strip("/\\")
+        return config.new_content_subfolder.strip("/\\")
+
+    def _target_file(self, project_dir: Path, config: SiteConfig) -> Path:
+        content_dir = project_dir / "content"
+        sub_folder = self._resolve_sub_folder(config)
+        if sub_folder == "":
+            target_dir = content_dir
+        else:
+            target_dir = content_dir / Path(sub_folder)
+        return target_dir / f"{_slugify_filename(self.title)}.md"
+
+    def _file_contents(self) -> str:
+        timestamp = datetime.now().date().isoformat()
+        return (
+            "---\n"
+            f'title: "{self.title}"\n'
+            f'timestamp: "{timestamp}"\n'
+            "---\n\n"
+        )
+
+    def execute(self) -> None:
+        project_dir = Path.cwd()
+        config = SiteConfig.load(project_dir)
+        target_file = self._target_file(project_dir, config)
+
+        if target_file.exists():
+            self._warning(f"Content file already exists: {target_file}")
+            return
+
+        if self._dry_run:
+            self._info(f"Dry run: would create content file {target_file}")
+            return
+
+        target_file.parent.mkdir(parents=True, exist_ok=True)
+        target_file.write_text(self._file_contents(), encoding="utf-8")
+        self._success(f"Created content file: {target_file}")

--- a/pyssg/main.py
+++ b/pyssg/main.py
@@ -62,7 +62,9 @@ def serve(
 @app.command()
 def new(
     title: str = typer.Argument(),
-    sub_folder: str | None = typer.Option(default=None, help="Optional content sub-folder."),
+    sub_folder: str | None = typer.Option(
+        default=None, help="Optional content sub-folder."
+    ),
     verbose: bool = typer.Option(default=False, help="Show additional details."),
     dry_run: bool = typer.Option(
         default=False, help="Preview changes without writing files."

--- a/pyssg/main.py
+++ b/pyssg/main.py
@@ -4,6 +4,7 @@ import typer
 
 from pyssg.commands.build import BuildCommand
 from pyssg.commands.init import InitCommand
+from pyssg.commands.new import NewCommand
 from pyssg.commands.serve import ServeCommand
 
 LOGGER = logging.getLogger(__name__)
@@ -56,6 +57,24 @@ def serve(
 ) -> None:
     serve_command = ServeCommand(port=port, verbose=verbose, dry_run=dry_run)
     serve_command.execute()
+
+
+@app.command()
+def new(
+    title: str = typer.Argument(),
+    sub_folder: str | None = typer.Option(default=None, help="Optional content sub-folder."),
+    verbose: bool = typer.Option(default=False, help="Show additional details."),
+    dry_run: bool = typer.Option(
+        default=False, help="Preview changes without writing files."
+    ),
+) -> None:
+    new_command = NewCommand(
+        title=title,
+        sub_folder=sub_folder,
+        verbose=verbose,
+        dry_run=dry_run,
+    )
+    new_command.execute()
 
 
 if __name__ == "__main__":

--- a/pyssg/modules/config.py
+++ b/pyssg/modules/config.py
@@ -109,6 +109,7 @@ class SiteConfig:
     static_dir: str = "static"
     static_dir_output: str = "static"
     content_sort: str = "date_desc"
+    new_content_subfolder: str = ""
     authors: list[AuthorConfig] = field(default_factory=list)
     feeds: list[FeedConfig] = field(default_factory=list)
     cache: bool = True
@@ -145,6 +146,7 @@ class SiteConfig:
             static_dir=str(data.get("static_dir", "static")),
             static_dir_output=static_dir_output,
             content_sort=content_sort,
+            new_content_subfolder=str(data.get("new_content_subfolder", "")),
             authors=authors,
             feeds=feeds,
             cache=bool(data.get("cache", True)),

--- a/pyssg/modules/html.py
+++ b/pyssg/modules/html.py
@@ -203,9 +203,9 @@ class HtmlTemplateEngine:
             result = jinja_template.render(**render_context)
         else:
             result = template
-        return self._render_components(result)
+        return self._render_components(result, render_context)
 
-    def _render_components(self, html: str) -> str:
+    def _render_components(self, html: str, context: dict[str, Any]) -> str:
         if not self.component_names or self.components_dir is None:
             return html
 
@@ -216,7 +216,7 @@ class HtmlTemplateEngine:
                 break
             replacements = [
                 self._get_component(match.name).render(
-                    **match.attrs, children=match.children
+                    **context, **match.attrs, children=match.children
                 )
                 for match in matches
             ]

--- a/pyssg/modules/html.py
+++ b/pyssg/modules/html.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
-from xml.etree.ElementTree import ParseError, fromstring
 
 from jinja2 import BaseLoader, Environment, Template
 
@@ -11,6 +10,8 @@ from pyssg.modules.config import SiteConfig
 _jinja_env = Environment(loader=BaseLoader(), autoescape=False)
 
 _TAG_TERMINATORS = frozenset(" />\n\t\r")
+_ATTR_NAME_TERMINATORS = frozenset("=>/ \n\t\r")
+_WHITESPACE = frozenset(" \n\t\r")
 
 
 @dataclass
@@ -30,17 +31,71 @@ def _build_line_offsets(html: str) -> list[int]:
     return offsets
 
 
+def _skip_chars(raw: str, index: int, chars: frozenset[str]) -> int:
+    while index < len(raw) and raw[index] in chars:
+        index += 1
+    return index
+
+
+def _read_until_chars(
+    raw: str, index: int, stop_chars: frozenset[str]
+) -> tuple[str, int]:
+    start = index
+    while index < len(raw) and raw[index] not in stop_chars:
+        index += 1
+    return raw[start:index], index
+
+
+def _read_tag_name(raw: str) -> tuple[str, int]:
+    return _read_until_chars(raw, 1, _TAG_TERMINATORS)
+
+
+def _read_attr_name(raw: str, index: int) -> tuple[str, int]:
+    return _read_until_chars(raw, index, _ATTR_NAME_TERMINATORS)
+
+
+def _read_quoted_attr_value(raw: str, index: int, quote: str) -> tuple[str, int]:
+    value, index = _read_until_chars(raw, index + 1, frozenset(quote))
+    if index < len(raw):
+        index += 1
+    return value, index
+
+
+def _read_unquoted_attr_value(raw: str, index: int) -> tuple[str, int]:
+    return _read_until_chars(raw, index, _TAG_TERMINATORS)
+
+
+def _read_attr_value(raw: str, index: int) -> tuple[str, int]:
+    if index >= len(raw) or raw[index] != "=":
+        return "", index
+
+    value_index = _skip_chars(raw, index + 1, _WHITESPACE)
+    if value_index >= len(raw):
+        return "", value_index
+    if raw[value_index] in "\"'":
+        return _read_quoted_attr_value(raw, value_index, raw[value_index])
+    return _read_unquoted_attr_value(raw, value_index)
+
+
 def _parse_raw_tag(raw: str) -> tuple[str, dict[str, str]]:
     """Return (tag_name, attrs) from a raw opening-tag string, preserving case."""
-    xml_frag = raw if raw.endswith("/>") else raw[:-1] + " />"
-    try:
-        elem = fromstring(xml_frag)
-        return elem.tag, dict(elem.attrib)
-    except ParseError:
-        name_end = 1
-        while name_end < len(raw) and raw[name_end] not in _TAG_TERMINATORS:
-            name_end += 1
-        return raw[1:name_end], {}
+    name, index = _read_tag_name(raw)
+
+    attrs: dict[str, str] = {}
+    while index < len(raw):
+        index = _skip_chars(raw, index, _WHITESPACE)
+        if index >= len(raw) or raw[index] in "/>":
+            break
+
+        attr_name, index = _read_attr_name(raw, index)
+        if attr_name == "":
+            break
+
+        index = _skip_chars(raw, index, _WHITESPACE)
+        attr_value, index = _read_attr_value(raw, index)
+        attrs[attr_name] = attr_value
+
+    return name, attrs
 
 
 class _ComponentParser(HTMLParser):

--- a/pyssg/modules/html.py
+++ b/pyssg/modules/html.py
@@ -6,8 +6,33 @@ from typing import Any
 from jinja2 import BaseLoader, Environment, Template
 
 from pyssg.modules.config import SiteConfig
+from pyssg.modules.template_helpers import (
+    date_format,
+    excerpt,
+    is_blog_post,
+    post_url,
+    slug,
+)
 
 _jinja_env = Environment(loader=BaseLoader(), autoescape=False)
+
+
+def _register_template_helpers() -> None:
+    _jinja_env.filters["date_format"] = date_format
+    _jinja_env.filters["excerpt"] = excerpt
+    _jinja_env.filters["slug"] = slug
+    setattr(
+        _jinja_env,
+        "globals",
+        {
+            **_jinja_env.globals,
+            "is_blog_post": is_blog_post,
+            "post_url": post_url,
+        },
+    )
+
+
+_register_template_helpers()
 
 _TAG_TERMINATORS = frozenset(" />\n\t\r")
 _ATTR_NAME_TERMINATORS = frozenset("=>/ \n\t\r")
@@ -253,11 +278,8 @@ class HtmlTemplateEngine:
             render_context["site"] = self.config
         if context:
             render_context.update(context)
-        if render_context:
-            jinja_template = _jinja_env.from_string(template)
-            result = jinja_template.render(**render_context)
-        else:
-            result = template
+        jinja_template = _jinja_env.from_string(template)
+        result = jinja_template.render(**render_context)
         return self._render_components(result, render_context)
 
     def _render_components(self, html: str, context: dict[str, Any]) -> str:

--- a/pyssg/modules/markdown.py
+++ b/pyssg/modules/markdown.py
@@ -24,6 +24,11 @@ def _slugify(text: str) -> str:
     return slug
 
 
+def content_url_from_filename(filename: str) -> str:
+    route = filename.removesuffix(".md").strip("/")
+    return f"/{route}/"
+
+
 def _to_json_safe_value(value: object) -> object:
     if value is None or isinstance(value, bool | int | float | str):
         return value
@@ -157,6 +162,10 @@ class MarkdownContent:
     author: ContentAuthor = field(default_factory=ContentAuthor)
     custom_fields: SimpleNamespace = field(default_factory=SimpleNamespace)
     toc: str = ""
+
+    @property
+    def url(self) -> str:
+        return content_url_from_filename(self.filename)
 
     @classmethod
     def from_raw(

--- a/pyssg/modules/markdown.py
+++ b/pyssg/modules/markdown.py
@@ -137,6 +137,10 @@ class MarkdownContentData(TypedDict):
     html: str
     title: str
     timestamp: str
+    slug: str
+    summary: str
+    subtitle: str
+    draft: bool
     tags: list[str]
     author: ContentAuthorData
     custom_fields: dict[str, object]
@@ -165,6 +169,10 @@ class MarkdownContent:
     html: str
     title: str = ""
     timestamp: str = ""
+    slug: str = ""
+    summary: str = ""
+    subtitle: str = ""
+    draft: bool = False
     tags: list[str] = field(default_factory=list)
     author: ContentAuthor = field(default_factory=ContentAuthor)
     custom_fields: SimpleNamespace = field(default_factory=SimpleNamespace)
@@ -202,6 +210,10 @@ class MarkdownContent:
             html=str(render(post.content)),
             title=str(post.get("title", "")),
             timestamp=_read_timestamp(post),
+            slug=str(post.get("slug", "")),
+            summary=str(post.get("summary", "")),
+            subtitle=str(post.get("subtitle", "")),
+            draft=bool(post.get("draft", False)),
             tags=tags,
             author=ContentAuthor.from_post(post),
             custom_fields=custom,
@@ -214,6 +226,10 @@ class MarkdownContent:
             "html": self.html,
             "title": self.title,
             "timestamp": self.timestamp,
+            "slug": self.slug,
+            "summary": self.summary,
+            "subtitle": self.subtitle,
+            "draft": self.draft,
             "tags": list(self.tags),
             "author": self.author.to_dict(),
             "custom_fields": cast(
@@ -238,6 +254,10 @@ class MarkdownContent:
             html=str(data.get("html", "")),
             title=str(data.get("title", "")),
             timestamp=str(data.get("timestamp", "")),
+            slug=str(data.get("slug", "")),
+            summary=str(data.get("summary", "")),
+            subtitle=str(data.get("subtitle", "")),
+            draft=bool(data.get("draft", False)),
             tags=tags,
             author=ContentAuthor.from_dict(author_data),
             custom_fields=SimpleNamespace(**cast(dict[str, Any], custom_fields_data)),

--- a/pyssg/modules/markdown.py
+++ b/pyssg/modules/markdown.py
@@ -29,6 +29,13 @@ def content_url_from_filename(filename: str) -> str:
     return f"/{route}/"
 
 
+def _read_timestamp(post: Any) -> str:
+    timestamp = post.get("timestamp", "")
+    if timestamp != "":
+        return str(timestamp)
+    return str(post.get("date", ""))
+
+
 def _to_json_safe_value(value: object) -> object:
     if value is None or isinstance(value, bool | int | float | str):
         return value
@@ -194,7 +201,7 @@ class MarkdownContent:
             filename=filename,
             html=str(render(post.content)),
             title=str(post.get("title", "")),
-            timestamp=str(post.get("timestamp", "")),
+            timestamp=_read_timestamp(post),
             tags=tags,
             author=ContentAuthor.from_post(post),
             custom_fields=custom,

--- a/pyssg/modules/rss.py
+++ b/pyssg/modules/rss.py
@@ -34,9 +34,9 @@ class RssFeedGenerator:
             item = SubElement(channel, "item")
             SubElement(item, "title").text = content.title
 
-            slug = content.filename.removesuffix(".md")
-            SubElement(item, "link").text = f"{self.site_url}/{slug}"
-            SubElement(item, "guid").text = f"{self.site_url}/{slug}"
+            canonical_url = f"{self.site_url}{content.url}"
+            SubElement(item, "link").text = canonical_url
+            SubElement(item, "guid").text = canonical_url
 
             SubElement(item, "description").text = content.html
 

--- a/pyssg/modules/template_helpers.py
+++ b/pyssg/modules/template_helpers.py
@@ -1,0 +1,56 @@
+import re
+from datetime import date, datetime
+from pathlib import PurePosixPath
+
+from pyssg.modules.markdown import MarkdownContent
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+_SLUG_STRIP_RE = re.compile(r"[^\w\s-]")
+_SLUG_SPACE_RE = re.compile(r"[\s]+")
+
+
+def post_url(post: MarkdownContent) -> str:
+    return post.url
+
+
+def is_blog_post(post: MarkdownContent) -> bool:
+    return PurePosixPath(post.filename).parts[:1] == ("blog",)
+
+
+def slug(value: object) -> str:
+    text = str(value).lower()
+    stripped = _SLUG_STRIP_RE.sub("", text)
+    return _SLUG_SPACE_RE.sub("-", stripped).strip("-")
+
+
+def _parse_datetime_value(value: object) -> date | datetime | None:
+    if isinstance(value, datetime | date):
+        return value
+    if not isinstance(value, str) or value == "":
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def date_format(value: object, fmt: str = "%Y-%m-%d") -> str:
+    parsed = _parse_datetime_value(value)
+    if parsed is None:
+        return str(value)
+    return parsed.strftime(fmt)
+
+
+def _normalize_excerpt_text(value: object) -> str:
+    without_tags = _HTML_TAG_RE.sub("", str(value))
+    return _WHITESPACE_RE.sub(" ", without_tags).strip()
+
+
+def excerpt(value: object, max_length: int = 160) -> str:
+    text = _normalize_excerpt_text(value)
+    if max_length < 0 or len(text) <= max_length:
+        return text
+    if max_length <= 3:
+        return text[:max_length]
+    return text[: max_length - 3].rstrip() + "..."

--- a/pyssg/templates/py-ssg.toml
+++ b/pyssg/templates/py-ssg.toml
@@ -6,6 +6,7 @@ cache = true
 static_dir = "static"
 static_dir_output = "static"
 content_sort = "date_desc"
+new_content_subfolder = ""
 
 [py-ssg.server]
 port = 8000

--- a/tests/app/commands/test_build.py
+++ b/tests/app/commands/test_build.py
@@ -422,6 +422,33 @@ def test_copy_template_directories_skips_render_only_template_files(
     )
 
 
+def test_copy_template_directories_skips_nested_html_page_templates(
+    tmp_path: Path,
+) -> None:
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    blog_dir = templates_dir / "blog"
+    blog_dir.mkdir()
+    (blog_dir / "index.html").write_text("<h1>Blog</h1>", encoding="utf-8")
+    (blog_dir / "meta.json").write_text('{"kind":"blog"}', encoding="utf-8")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    paths = BuildPaths(
+        project_dir=tmp_path,
+        templates_dir=templates_dir,
+        components_dir=tmp_path / "components",
+        output_dir=output_dir,
+    )
+    command = BuildCommand()
+
+    command._copy_template_directories(paths)
+
+    assert not (output_dir / "blog" / "index.html").exists()
+    assert (output_dir / "blog" / "meta.json").read_text(encoding="utf-8") == (
+        '{"kind":"blog"}'
+    )
+
+
 def test_render_template_file_builds_static_template(tmp_path: Path) -> None:
     templates_dir = tmp_path / "templates"
     templates_dir.mkdir()
@@ -600,6 +627,40 @@ def test_render_template_files_skips_render_only_template_files(tmp_path: Path) 
     assert summary == (1, 1, 0)
     assert engine.render.call_count == 1
     assert not (output_dir / "post.tmpl.html").exists()
+
+
+def test_render_template_files_renders_nested_html_templates(tmp_path: Path) -> None:
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    blog_dir = templates_dir / "blog"
+    blog_dir.mkdir()
+    (blog_dir / "index.html").write_text("<h1>Blog</h1>", encoding="utf-8")
+    (blog_dir / "post.html").write_text("<article>Post</article>", encoding="utf-8")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    engine = MagicMock()
+    engine.render.side_effect = ["<h1>Rendered blog</h1>", "<article>Rendered post</article>"]
+    cache = MagicMock()
+    cache.has_dynamic_constructs.return_value = False
+    cache.needs_rebuild.return_value = True
+    command = SilentBuildCommand()
+
+    summary = command._render_template_files(
+        templates_dir=templates_dir,
+        output_dir=output_dir,
+        engine=engine,
+        collection=_make_collection(),
+        cache=cache,
+        content_sort="date_desc",
+    )
+
+    assert summary == (2, 2, 0)
+    assert (output_dir / "blog" / "index.html").read_text(encoding="utf-8") == (
+        "<h1>Rendered blog</h1>"
+    )
+    assert (output_dir / "blog" / "post.html").read_text(encoding="utf-8") == (
+        "<article>Rendered post</article>"
+    )
 
 
 def test_render_template_files_passes_immutable_sorted_content(tmp_path: Path) -> None:

--- a/tests/app/commands/test_build.py
+++ b/tests/app/commands/test_build.py
@@ -395,6 +395,33 @@ def test_copy_template_directories_replaces_existing_directory(tmp_path: Path) -
     assert (output_dir / "assets" / "new.css").read_text(encoding="utf-8") == "new"
 
 
+def test_copy_template_directories_skips_render_only_template_files(
+    tmp_path: Path,
+) -> None:
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    blog_dir = templates_dir / "blog"
+    blog_dir.mkdir()
+    (blog_dir / "post.tmpl.html").write_text("<article>{{ post.html }}</article>")
+    (blog_dir / "meta.json").write_text('{"kind":"blog"}', encoding="utf-8")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    paths = BuildPaths(
+        project_dir=tmp_path,
+        templates_dir=templates_dir,
+        components_dir=tmp_path / "components",
+        output_dir=output_dir,
+    )
+    command = BuildCommand()
+
+    command._copy_template_directories(paths)
+
+    assert not (output_dir / "blog" / "post.tmpl.html").exists()
+    assert (output_dir / "blog" / "meta.json").read_text(encoding="utf-8") == (
+        '{"kind":"blog"}'
+    )
+
+
 def test_render_template_file_builds_static_template(tmp_path: Path) -> None:
     templates_dir = tmp_path / "templates"
     templates_dir.mkdir()
@@ -543,6 +570,36 @@ def test_render_template_files_counts_only_html_files(tmp_path: Path) -> None:
 
     assert summary == (2, 2, 0)
     assert engine.render.call_count == 2
+
+
+def test_render_template_files_skips_render_only_template_files(tmp_path: Path) -> None:
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "index.html").write_text("<h1>Home</h1>", encoding="utf-8")
+    (templates_dir / "post.tmpl.html").write_text(
+        "<article>{{ post.html }}</article>", encoding="utf-8"
+    )
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    engine = MagicMock()
+    engine.render.return_value = "<h1>Home</h1>"
+    cache = MagicMock()
+    cache.has_dynamic_constructs.return_value = False
+    cache.needs_rebuild.return_value = True
+    command = SilentBuildCommand()
+
+    summary = command._render_template_files(
+        templates_dir=templates_dir,
+        output_dir=output_dir,
+        engine=engine,
+        collection=_make_collection(),
+        cache=cache,
+        content_sort="date_desc",
+    )
+
+    assert summary == (1, 1, 0)
+    assert engine.render.call_count == 1
+    assert not (output_dir / "post.tmpl.html").exists()
 
 
 def test_render_template_files_passes_immutable_sorted_content(tmp_path: Path) -> None:

--- a/tests/app/commands/test_build.py
+++ b/tests/app/commands/test_build.py
@@ -639,7 +639,10 @@ def test_render_template_files_renders_nested_html_templates(tmp_path: Path) -> 
     output_dir = tmp_path / "output"
     output_dir.mkdir()
     engine = MagicMock()
-    engine.render.side_effect = ["<h1>Rendered blog</h1>", "<article>Rendered post</article>"]
+    engine.render.side_effect = [
+        "<h1>Rendered blog</h1>",
+        "<article>Rendered post</article>",
+    ]
     cache = MagicMock()
     cache.has_dynamic_constructs.return_value = False
     cache.needs_rebuild.return_value = True

--- a/tests/app/commands/test_build.py
+++ b/tests/app/commands/test_build.py
@@ -709,6 +709,46 @@ def test_render_content_pages_generates_pages_from_content_templates(
     ) == "<article>Hello World</article>"
 
 
+@patch.object(BuildCommand, "_warning")
+def test_render_content_pages_warns_when_content_template_is_not_render_only(
+    mock_warning: MagicMock, tmp_path: Path
+) -> None:
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    blog_dir = templates_dir / "blog"
+    blog_dir.mkdir()
+    (blog_dir / "post.html").write_text(
+        "<article>{{ post.title }}</article>", encoding="utf-8"
+    )
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    post = MarkdownContent(
+        filename="blog/hello-world.md",
+        html="<p>Hello</p>",
+        title="Hello World",
+        custom_fields=SimpleNamespace(template="blog/post.html"),
+    )
+    engine = MagicMock()
+    engine.render.return_value = "<article>Hello World</article>"
+    cache = MagicMock()
+    command = SilentBuildCommand()
+
+    command._render_content_pages(
+        templates_dir=templates_dir,
+        output_dir=output_dir,
+        engine=engine,
+        collection=_make_collection(post),
+        cache=cache,
+        content_sort="date_desc",
+    )
+
+    mock_warning.assert_called_once_with(
+        "Content template blog/post.html is not render-only and will also be "
+        "rendered as a standalone page. Rename it to blog/post.tmpl.html if "
+        "it should only be used through frontmatter."
+    )
+
+
 def test_render_template_files_passes_immutable_sorted_content(tmp_path: Path) -> None:
     templates_dir = tmp_path / "templates"
     templates_dir.mkdir()

--- a/tests/app/commands/test_build.py
+++ b/tests/app/commands/test_build.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from types import MappingProxyType
+from types import MappingProxyType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from pyssg.commands.build import (
@@ -661,6 +661,52 @@ def test_render_template_files_renders_nested_html_templates(tmp_path: Path) -> 
     assert (output_dir / "blog" / "post.html").read_text(encoding="utf-8") == (
         "<article>Rendered post</article>"
     )
+
+
+def test_render_content_pages_generates_pages_from_content_templates(
+    tmp_path: Path,
+) -> None:
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    blog_dir = templates_dir / "blog"
+    blog_dir.mkdir()
+    (blog_dir / "post.tmpl.html").write_text(
+        "<article>{{ post.title }}</article>", encoding="utf-8"
+    )
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    post = MarkdownContent(
+        filename="blog/hello-world.md",
+        html="<p>Hello</p>",
+        title="Hello World",
+        custom_fields=SimpleNamespace(template="blog/post.tmpl.html"),
+    )
+    engine = MagicMock()
+    engine.render.return_value = "<article>Hello World</article>"
+    cache = MagicMock()
+    command = SilentBuildCommand()
+
+    summary = command._render_content_pages(
+        templates_dir=templates_dir,
+        output_dir=output_dir,
+        engine=engine,
+        collection=_make_collection(post),
+        cache=cache,
+        content_sort="date_desc",
+    )
+
+    assert summary == (1, 1, 0)
+    engine.render.assert_called_once_with(
+        "<article>{{ post.title }}</article>",
+        context={
+            "content": (post,),
+            "tags": MappingProxyType({}),
+            "post": post,
+        },
+    )
+    assert (output_dir / "blog" / "hello-world" / "index.html").read_text(
+        encoding="utf-8"
+    ) == "<article>Hello World</article>"
 
 
 def test_render_template_files_passes_immutable_sorted_content(tmp_path: Path) -> None:

--- a/tests/app/commands/test_new.py
+++ b/tests/app/commands/test_new.py
@@ -22,10 +22,7 @@ def test_execute_creates_new_content_file_in_sub_folder(
     created = tmp_path / "content" / "blog" / "post_title.md"
     assert created.is_file()
     assert created.read_text(encoding="utf-8") == (
-        "---\n"
-        'title: "Post Title"\n'
-        'timestamp: "2025-01-15"\n'
-        "---\n\n"
+        '---\ntitle: "Post Title"\ntimestamp: "2025-01-15"\n---\n\n'
     )
 
 

--- a/tests/app/commands/test_new.py
+++ b/tests/app/commands/test_new.py
@@ -1,0 +1,78 @@
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pyssg.commands.new import NewCommand
+from pyssg.modules.config import SiteConfig
+
+TEST_PATH = "pyssg.commands.new"
+
+
+@patch(f"{TEST_PATH}.datetime")
+def test_execute_creates_new_content_file_in_sub_folder(
+    mock_datetime: MagicMock, tmp_path: Path
+) -> None:
+    mock_datetime.now.return_value = datetime(2025, 1, 15, 12, 30, 0)
+    (tmp_path / "content").mkdir()
+    command = NewCommand(title="Post Title", sub_folder="blog")
+
+    with patch(f"{TEST_PATH}.Path.cwd", return_value=tmp_path):
+        command.execute()
+
+    created = tmp_path / "content" / "blog" / "post_title.md"
+    assert created.is_file()
+    assert created.read_text(encoding="utf-8") == (
+        "---\n"
+        'title: "Post Title"\n'
+        'timestamp: "2025-01-15"\n'
+        "---\n\n"
+    )
+
+
+@patch(f"{TEST_PATH}.datetime")
+@patch(f"{TEST_PATH}.SiteConfig")
+def test_execute_uses_default_sub_folder_from_config(
+    mock_config_cls: MagicMock,
+    mock_datetime: MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_datetime.now.return_value = datetime(2025, 1, 15, 12, 30, 0)
+    (tmp_path / "content").mkdir()
+    mock_config_cls.load.return_value = SiteConfig(new_content_subfolder="notes")
+    command = NewCommand(title="Post Title")
+
+    with patch(f"{TEST_PATH}.Path.cwd", return_value=tmp_path):
+        command.execute()
+
+    assert (tmp_path / "content" / "notes" / "post_title.md").is_file()
+
+
+@patch(f"{TEST_PATH}.datetime")
+def test_execute_dry_run_does_not_write_file(
+    mock_datetime: MagicMock, tmp_path: Path
+) -> None:
+    mock_datetime.now.return_value = datetime(2025, 1, 15, 12, 30, 0)
+    (tmp_path / "content").mkdir()
+    command = NewCommand(title="Post Title", sub_folder="blog", dry_run=True)
+
+    with patch(f"{TEST_PATH}.Path.cwd", return_value=tmp_path):
+        command.execute()
+
+    assert not (tmp_path / "content" / "blog" / "post_title.md").exists()
+
+
+@patch.object(NewCommand, "_warning")
+def test_execute_warns_and_skips_when_file_exists(
+    mock_warning: MagicMock, tmp_path: Path
+) -> None:
+    content_dir = tmp_path / "content" / "blog"
+    content_dir.mkdir(parents=True)
+    existing = content_dir / "post_title.md"
+    existing.write_text("existing", encoding="utf-8")
+    command = NewCommand(title="Post Title", sub_folder="blog")
+
+    with patch(f"{TEST_PATH}.Path.cwd", return_value=tmp_path):
+        command.execute()
+
+    mock_warning.assert_called_once_with(f"Content file already exists: {existing}")
+    assert existing.read_text(encoding="utf-8") == "existing"

--- a/tests/app/modules/test_config.py
+++ b/tests/app/modules/test_config.py
@@ -110,6 +110,7 @@ class TestSiteConfig:
         assert config.static_dir == "static"
         assert config.static_dir_output == "static"
         assert config.content_sort == "date_desc"
+        assert config.new_content_subfolder == ""
         assert config.authors == []
         assert config.feeds == []
         assert config.cache is True
@@ -124,6 +125,7 @@ class TestSiteConfig:
             "static_dir": "public",
             "static_dir_output": "root",
             "content_sort": "filename",
+            "new_content_subfolder": "blog",
             "cache": False,
             "authors": [{"name": "Jane", "email": "jane@example.com"}],
             "feeds": [{"title": "Feed", "output": "feed.xml"}],
@@ -137,6 +139,7 @@ class TestSiteConfig:
         assert config.static_dir == "public"
         assert config.static_dir_output == "root"
         assert config.content_sort == "filename"
+        assert config.new_content_subfolder == "blog"
         assert config.cache is False
         assert len(config.authors) == 1
         assert config.authors[0].name == "Jane"
@@ -153,6 +156,7 @@ class TestSiteConfig:
         assert config.static_dir == "static"
         assert config.static_dir_output == "static"
         assert config.content_sort == "date_desc"
+        assert config.new_content_subfolder == ""
         assert config.authors == []
         assert config.feeds == []
         assert config.cache is True

--- a/tests/app/modules/test_html.py
+++ b/tests/app/modules/test_html.py
@@ -225,7 +225,9 @@ class TestRenderTemplate:
     def test_builtin_excerpt_filter(self):
         engine = self._make_engine()
 
-        result = engine.render("{{ '<p>Hello <strong>world</strong> again</p>'|excerpt(11) }}")
+        result = engine.render(
+            "{{ '<p>Hello <strong>world</strong> again</p>'|excerpt(11) }}"
+        )
 
         assert result == "Hello wo..."
 

--- a/tests/app/modules/test_html.py
+++ b/tests/app/modules/test_html.py
@@ -189,6 +189,46 @@ class TestRenderTemplate:
         assert "<header>Site Header</header>" in result
         assert "<p>My Post</p>" in result
 
+    def test_builtin_post_url_global(self):
+        engine = self._make_engine()
+        post = MarkdownContent(filename="blog/hello-world.md", html="<p>Hello</p>")
+
+        result = engine.render("{{ post_url(post) }}", context={"post": post})
+
+        assert result == "/blog/hello-world/"
+
+    def test_builtin_is_blog_post_global(self):
+        engine = self._make_engine()
+        post = MarkdownContent(filename="blog/hello-world.md", html="<p>Hello</p>")
+
+        result = engine.render(
+            "{% if is_blog_post(post) %}yes{% else %}no{% endif %}",
+            context={"post": post},
+        )
+
+        assert result == "yes"
+
+    def test_builtin_slug_filter(self):
+        engine = self._make_engine()
+
+        result = engine.render("{{ 'Hello, World!'|slug }}")
+
+        assert result == "hello-world"
+
+    def test_builtin_date_format_filter(self):
+        engine = self._make_engine()
+
+        result = engine.render("{{ '2025-01-15T12:30:00'|date_format('%Y-%m') }}")
+
+        assert result == "2025-01"
+
+    def test_builtin_excerpt_filter(self):
+        engine = self._make_engine()
+
+        result = engine.render("{{ '<p>Hello <strong>world</strong> again</p>'|excerpt(11) }}")
+
+        assert result == "Hello wo..."
+
 
 class TestSiteConfigInTemplates:
     def test_site_name_available_in_template(self):

--- a/tests/app/modules/test_html.py
+++ b/tests/app/modules/test_html.py
@@ -368,6 +368,24 @@ class TestComponentChildren:
         assert "<p>second</p>" in result
 
 
+class TestComponentParentContext:
+    def test_component_receives_site_and_parent_template_context(self):
+        config = SiteConfig(name="My Blog")
+        engine = HtmlTemplateEngine(
+            templates_dir=Path("/templates"),
+            components_dir=Path("/components"),
+            component_names=["Banner"],
+            config=config,
+        )
+        template = "<Banner />"
+        banner_html = "<header>{{ site.name }} {{ section }}</header>"
+
+        with patch(f"{TEST_PATH}.open", mock_open(read_data=banner_html)):
+            result = engine.render(template, context={"section": "News"})
+
+        assert "<header>My Blog News</header>" in result
+
+
 class TestDotSyntaxComponents:
     def test_dot_syntax_resolves_to_subdirectory(self):
         engine = HtmlTemplateEngine(

--- a/tests/app/modules/test_html_components.py
+++ b/tests/app/modules/test_html_components.py
@@ -56,7 +56,7 @@ class TestFindComponentTags:
         }
 
     def test_preserves_html_rich_attribute_values(self):
-        html = '<Alert message="<a href=\'/\'>Home</a>" />'
+        html = "<Alert message=\"<a href='/'>Home</a>\" />"
         matches = find_component_tags(html, {"Alert"})
 
         assert matches[0].attrs == {"message": "<a href='/'>Home</a>"}

--- a/tests/app/modules/test_html_components.py
+++ b/tests/app/modules/test_html_components.py
@@ -55,6 +55,12 @@ class TestFindComponentTags:
             "message": "Hello",
         }
 
+    def test_preserves_html_rich_attribute_values(self):
+        html = '<Alert message="<a href=\'/\'>Home</a>" />'
+        matches = find_component_tags(html, {"Alert"})
+
+        assert matches[0].attrs == {"message": "<a href='/'>Home</a>"}
+
     def test_skips_regular_html_tags(self):
         html = '<div class="foo" /><Navbar />'
         matches = find_component_tags(html, {"Navbar"})

--- a/tests/app/modules/test_markdown.py
+++ b/tests/app/modules/test_markdown.py
@@ -211,7 +211,9 @@ class TestMarkdownContent:
         json.dumps(data)
 
     def test_url_uses_nested_content_path(self):
-        content = MarkdownContent(filename="blog/2025/hello-world.md", html="<p>Hello</p>")
+        content = MarkdownContent(
+            filename="blog/2025/hello-world.md", html="<p>Hello</p>"
+        )
 
         assert content.url == "/blog/2025/hello-world/"
 

--- a/tests/app/modules/test_markdown.py
+++ b/tests/app/modules/test_markdown.py
@@ -68,6 +68,10 @@ class TestMarkdownContent:
         assert content.url == "/test/"
         assert content.title == ""
         assert content.timestamp == ""
+        assert content.slug == ""
+        assert content.summary == ""
+        assert content.subtitle == ""
+        assert content.draft is False
         assert content.tags == []
         assert content.author == ContentAuthor()
 
@@ -121,14 +125,33 @@ class TestMarkdownContent:
         assert content.author.name == "Jane"
         assert content.author.email == "jane@example.com"
 
-    def test_from_raw_puts_unknown_fields_in_custom_fields(self):
-        raw = "---\ntitle: Post\nslug: my-post\ndraft: true\n---\n\nContent"
+    def test_from_raw_parses_builtin_optional_fields(self):
+        raw = (
+            "---\ntitle: Post\nslug: my-post\ndraft: true\nsubtitle: Intro\n"
+            "summary: Short summary\n---\n\nContent"
+        )
 
         content = MarkdownContent.from_raw("post.md", raw)
 
         assert content.title == "Post"
-        assert content.custom_fields.slug == "my-post"
-        assert content.custom_fields.draft is True
+        assert content.slug == "my-post"
+        assert content.draft is True
+        assert content.subtitle == "Intro"
+        assert content.summary == "Short summary"
+
+    def test_from_raw_keeps_only_unknown_fields_in_custom_fields(self):
+        raw = (
+            "---\ntitle: Post\nslug: my-post\ndraft: true\nsubtitle: Intro\n"
+            "summary: Short summary\nseries: Python Notes\n---\n\nContent"
+        )
+
+        content = MarkdownContent.from_raw("post.md", raw)
+
+        assert not hasattr(content.custom_fields, "slug")
+        assert not hasattr(content.custom_fields, "draft")
+        assert not hasattr(content.custom_fields, "subtitle")
+        assert not hasattr(content.custom_fields, "summary")
+        assert content.custom_fields.series == "Python Notes"
 
     def test_from_raw_with_no_frontmatter(self):
         content = MarkdownContent.from_raw("post.md", "Just plain markdown")
@@ -143,9 +166,13 @@ class TestMarkdownContent:
             html="<p>Hello</p>",
             title="Post",
             timestamp="2025-01-15",
+            slug="post",
+            summary="Summary",
+            subtitle="Subtitle",
+            draft=True,
             tags=["python"],
             author=ContentAuthor(name="Jane", email="jane@example.com"),
-            custom_fields=SimpleNamespace(slug="post", draft=True),
+            custom_fields=SimpleNamespace(series="notes"),
             toc="<nav>...</nav>",
         )
 
@@ -169,6 +196,10 @@ class TestMarkdownContent:
 
         data = content.to_dict()
 
+        assert data["slug"] == ""
+        assert data["summary"] == ""
+        assert data["subtitle"] == ""
+        assert data["draft"] is False
         assert data["custom_fields"] == {
             "published_on": "2025-01-15",
             "updated_at": "2025-01-15 12:30:45",
@@ -515,8 +546,8 @@ Content here.
 
         post = result["post.md"]
         assert post.title == "My Post"
-        assert post.custom_fields.slug == "my-post"
-        assert post.custom_fields.draft is True
+        assert post.slug == "my-post"
+        assert post.draft is True
 
     def test_no_frontmatter_returns_defaults(self, tmp_path):
         (tmp_path / "post.md").write_text("Just plain markdown")

--- a/tests/app/modules/test_markdown.py
+++ b/tests/app/modules/test_markdown.py
@@ -96,6 +96,23 @@ class TestMarkdownContent:
         assert content.tags == ["python"]
         assert "<p>Body</p>" in content.html
 
+    def test_from_raw_supports_date_as_timestamp_alias(self):
+        raw = '---\ntitle: My Post\ndate: "2025-01-15"\n---\n\nBody'
+
+        content = MarkdownContent.from_raw("post.md", raw)
+
+        assert content.timestamp == "2025-01-15"
+
+    def test_from_raw_prefers_timestamp_when_date_and_timestamp_exist(self):
+        raw = (
+            '---\ntitle: My Post\ntimestamp: "2025-01-16"\n'
+            'date: "2025-01-15"\n---\n\nBody'
+        )
+
+        content = MarkdownContent.from_raw("post.md", raw)
+
+        assert content.timestamp == "2025-01-16"
+
     def test_from_raw_parses_author(self):
         raw = "---\nauthor: Jane\nauthor_email: jane@example.com\n---\n\nHi"
 
@@ -466,6 +483,21 @@ author_url: https://example.com
         assert post.author.avatar == "https://example.com/avatar.png"
         assert post.author.url == "https://example.com"
         assert "<h1>Hello World</h1>" in post.html
+
+    def test_parses_date_as_timestamp_alias(self, tmp_path):
+        md_content = """---
+title: My Post
+date: "2025-01-15"
+---
+
+# Hello World
+"""
+        (tmp_path / "post.md").write_text(md_content)
+        parser = MarkdownParser(content_dir=tmp_path)
+
+        result = parser.parse()
+
+        assert result["post.md"].timestamp == "2025-01-15"
 
     def test_parses_custom_fields(self, tmp_path):
         md_content = """---

--- a/tests/app/modules/test_markdown.py
+++ b/tests/app/modules/test_markdown.py
@@ -65,6 +65,7 @@ class TestMarkdownContent:
 
         assert content.filename == "test.md"
         assert content.html == "<p>Hello</p>"
+        assert content.url == "/test/"
         assert content.title == ""
         assert content.timestamp == ""
         assert content.tags == []
@@ -83,6 +84,7 @@ class TestMarkdownContent:
         assert "<h1>Hello</h1>" in content.html
         assert "<p>World</p>" in content.html
         assert content.filename == "test.md"
+        assert content.url == "/test/"
 
     def test_from_raw_parses_frontmatter(self):
         raw = '---\ntitle: My Post\ntimestamp: "2025-01-15"\ntags:\n  - python\n---\n\nBody'
@@ -159,6 +161,11 @@ class TestMarkdownContent:
             },
         }
         json.dumps(data)
+
+    def test_url_uses_nested_content_path(self):
+        content = MarkdownContent(filename="blog/2025/hello-world.md", html="<p>Hello</p>")
+
+        assert content.url == "/blog/2025/hello-world/"
 
 
 class TestMarkdownCollection:

--- a/tests/app/modules/test_rss.py
+++ b/tests/app/modules/test_rss.py
@@ -48,7 +48,7 @@ class TestRssFeedGenerator:
         assert '<?xml version="1.0"' in xml
         assert "<title>Blog</title>" in xml
         assert "<title>Test Post</title>" in xml
-        assert "<link>https://example.com/post</link>" in xml
+        assert "<link>https://example.com/post/</link>" in xml
 
     def test_generate_multiple_feeds(self):
         feeds = [
@@ -67,10 +67,10 @@ class TestRssFeedGenerator:
         assert len(results) == 2
         all_xml = results[0][1]
         tech_xml = results[1][1]
-        assert "a</link>" in all_xml
-        assert "b</link>" in all_xml
-        assert "a</link>" in tech_xml
-        assert "b</link>" not in tech_xml
+        assert "a/</link>" in all_xml
+        assert "b/</link>" in all_xml
+        assert "a/</link>" in tech_xml
+        assert "b/</link>" not in tech_xml
 
     def test_tag_filtering(self):
         feed = FeedConfig(title="Tech", output="tech.xml", tags=["tech"])
@@ -85,9 +85,21 @@ class TestRssFeedGenerator:
         results = gen.generate(col)
         xml = results[0][1]
 
-        assert "https://example.com/a</link>" in xml
-        assert "https://example.com/c</link>" in xml
-        assert "https://example.com/b</link>" not in xml
+        assert "https://example.com/a/</link>" in xml
+        assert "https://example.com/c/</link>" in xml
+        assert "https://example.com/b/</link>" not in xml
+
+    def test_feed_links_use_same_route_as_post_url(self):
+        feed = FeedConfig(title="Blog", output="feed.xml")
+        config = _make_config(feeds=[feed])
+        gen = RssFeedGenerator(config=config)
+        col = _make_collection(_make_content(filename="blog/hello-world.md"))
+
+        results = gen.generate(col)
+        xml = results[0][1]
+
+        assert "<link>https://example.com/blog/hello-world/</link>" in xml
+        assert "<guid>https://example.com/blog/hello-world/</guid>" in xml
 
     def test_items_sorted_by_timestamp_descending(self):
         feed = FeedConfig(title="Blog", output="feed.xml")
@@ -102,9 +114,9 @@ class TestRssFeedGenerator:
         results = gen.generate(col)
         xml = results[0][1]
 
-        new_pos = xml.index("example.com/new")
-        mid_pos = xml.index("example.com/mid")
-        old_pos = xml.index("example.com/old")
+        new_pos = xml.index("example.com/new/")
+        mid_pos = xml.index("example.com/mid/")
+        old_pos = xml.index("example.com/old/")
         assert new_pos < mid_pos < old_pos
 
     def test_author_with_email(self):
@@ -158,5 +170,5 @@ class TestRssFeedGenerator:
 
         results = gen.generate(col)
         xml = results[0][1]
-        assert "https://example.com/post</link>" in xml
-        assert "example.com//post" not in xml
+        assert "https://example.com/post/</link>" in xml
+        assert "example.com//post/" not in xml

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -38,3 +38,22 @@ def test_serve_passes_port_verbose_and_dry_run_to_command(mock_serve_cls) -> Non
     assert result.exit_code == 0
     mock_serve_cls.assert_called_once_with(port=9000, verbose=True, dry_run=True)
     mock_serve_cls.return_value.execute.assert_called_once_with()
+
+
+@patch(f"{TEST_PATH}.NewCommand")
+def test_new_passes_title_sub_folder_verbose_and_dry_run_to_command(
+    mock_new_cls,
+) -> None:
+    result = runner.invoke(
+        app,
+        ["new", "--sub-folder", "blog", "Post Title", "--verbose", "--dry-run"],
+    )
+
+    assert result.exit_code == 0
+    mock_new_cls.assert_called_once_with(
+        title="Post Title",
+        sub_folder="blog",
+        verbose=True,
+        dry_run=True,
+    )
+    mock_new_cls.return_value.execute.assert_called_once_with()

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ wheels = [
 
 [[package]]
 name = "py-ssg"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
This release adds two major features and improves command-line ergonomics.

FEATURES

Add `py-ssg new` command that scaffolds new markdown content files with starter frontmatter. The command supports optional sub-folder placement, respects project-level defaults, and includes dry-run preview capability.

Enable content-generated pages: Markdown files can now set a `template` field in frontmatter to render as standalone output pages without manual pyssg_build.py integration. Content pages receive site context, content list, tag map, and the current post object.

Add built-in template helpers and filters accessible in all templates. New globals include `post_url(post)` for canonical routes and `is_blog_post(post)` for blog detection. New filters include `slug` for URL-safe slugification, `date_format` for datetime rendering with strftime syntax, and `excerpt` for HTML-stripping text truncation.

Add optional built-in frontmatter fields: slug, summary, subtitle, and draft. These fields are now parsed as first-class properties rather than custom fields, making them available consistently across all content objects.

IMPROVEMENTS

Support `date` as an alias for `timestamp` in frontmatter, accepting both field names interchangeably.

Add `--verbose` and `--dry-run` flags to init, build, serve, and new commands for consistent preview and debugging capability across the CLI.

Fix template filtering to skip render-only templates (*.tmpl.html) from direct output while still allowing use as content templates. Warn when frontmatter templates point to non-render-only files that will also render as standalone pages.

Improve component attribute parsing to support HTML-rich quoted values and eliminate brittle XML parsing.

Pass parent template context to components, allowing components to access site, content, tags, post, and other parent-scope variables.

Support nested template directories: templates in subdirectories such as templates/blog/ now render to matching nested output paths.

Update RSS feed URL generation to use canonical post.url routes, ensuring feed links align with frontmatter template and standard page routing.

Add `new_content_subfolder` configuration option to set project-level defaults for content file placement.

Update documentation with command flags, behavior notes, content routing explanation, and template helper reference.

Bump version to 0.2.2.