### PR TITLE
Add asset_url template helper for cache-busting assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ If your project has a `static/` directory, py-ssg copies it on every build after
 
 With the default layout, reference assets from templates with paths like `/static/styles.css` or `/static/favicon.ico`.
 
+Use `{{ asset_url(...) }}` for local CSS, JS, images, and `syntax.css` so rebuilt assets get a new query-string version and browsers fetch the latest file instead of serving a stale cached copy.
+
 When using `static_dir_output = "root"`, avoid filename collisions with generated pages and assets such as `index.html`, `feed.xml`, and `syntax.css` unless you intentionally want the static file to take precedence.
 
 ## Markdown Content
@@ -357,6 +359,7 @@ Templates also have these built-in globals and filters:
 |--------|------|-------------|
 | `post_url(post)` | global | Returns the canonical URL for a content item, such as `/blog/hello-world/` |
 | `is_blog_post(post)` | global | Returns `true` when the content file lives under `content/blog/` |
+| `asset_url(path)` | global | Appends a build version query string to local output assets such as `/static/styles.css` or `syntax.css` |
 | `slug` | filter | Slugifies text by lowercasing it, removing special characters, and replacing spaces with hyphens |
 | `date_format` | filter | Formats ISO date or datetime strings with `strftime` syntax, for example `{{ post.timestamp\|date_format('%Y-%m-%d') }}` |
 | `excerpt` | filter | Strips HTML, normalizes whitespace, and truncates text with `...` |
@@ -368,7 +371,8 @@ Templates also have these built-in globals and filters:
 <html>
 <head>
   <title>{{ site.name }}</title>
-  <link rel="stylesheet" href="syntax.css">
+  <link rel="stylesheet" href="{{ asset_url('syntax.css') }}">
+  <link rel="stylesheet" href="{{ asset_url('/static/styles.css') }}">
 </head>
 <body>
   <Navbar homeClass="active" />
@@ -493,7 +497,7 @@ def hello():
 The build generates an `output/syntax.css` file with dual-theme support using `@media (prefers-color-scheme)`. Link it in your templates:
 
 ```html
-<link rel="stylesheet" href="syntax.css">
+<link rel="stylesheet" href="{{ asset_url('syntax.css') }}">
 ```
 
 Any language supported by Pygments can be used. If a language is not recognized, the block falls back to plain text. You can use any valid [Pygments style name](https://pygments.org/styles/) for `theme_light` and `theme_dark`.

--- a/pyssg/commands/build.py
+++ b/pyssg/commands/build.py
@@ -1,4 +1,6 @@
+import hashlib
 import os
+import posixpath
 import shutil
 import time
 from collections import defaultdict
@@ -7,6 +9,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from types import MappingProxyType
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from pyssg.commands.base_command import BaseCommand
 from pyssg.modules.build_script import BuildContext, BuildScript
@@ -96,6 +99,50 @@ def _copy_static_assets(
     dest = mode.destination(output_dir)
     shutil.copytree(static_dir, dest, dirs_exist_ok=os.path.exists(dest))
     return mode.output_path
+
+
+def _compute_asset_version(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()[:12]
+
+
+def _normalize_asset_lookup_path(path: str) -> str:
+    normalized = posixpath.normpath(path.lstrip("/"))
+    return "" if normalized == "." else normalized
+
+
+@dataclass(frozen=True)
+class AssetVersionManifest:
+    versions: Mapping[str, str]
+
+    def asset_url(self, path: str) -> str:
+        parsed = urlsplit(path)
+        if parsed.scheme != "" or parsed.netloc != "":
+            return path
+
+        lookup_path = _normalize_asset_lookup_path(parsed.path)
+        if lookup_path == "":
+            return path
+
+        version = self.versions.get(lookup_path)
+        if version is None:
+            return path
+
+        query_items = parse_qsl(parsed.query, keep_blank_values=True)
+        query_items.append(("v", version))
+        return urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                parsed.path,
+                urlencode(query_items),
+                parsed.fragment,
+            )
+        )
+
+    def fingerprint(self) -> str:
+        return "|".join(
+            f"{path}={version}" for path, version in sorted(self.versions.items())
+        )
 
 
 @dataclass
@@ -259,12 +306,19 @@ class BuildCommand(BaseCommand):
         self._info("Rendering templates")
         rendering_start = time.perf_counter()
         component_names = _discover_components(paths.components_dir)
+        asset_manifest = self._build_asset_manifest(
+            paths=paths,
+            config=config,
+            highlighter=highlighter,
+        )
         engine = HtmlTemplateEngine(
             templates_dir=paths.templates_dir,
             components_dir=paths.components_dir,
             component_names=component_names,
             config=config,
+            asset_manifest=asset_manifest,
         )
+        cache_seed = asset_manifest.fingerprint()
         self._detail(f"Discovered {len(component_names)} components")
         if not self._dry_run:
             os.makedirs(paths.output_dir, exist_ok=True)
@@ -282,6 +336,7 @@ class BuildCommand(BaseCommand):
             collection=collection,
             cache=cache,
             content_sort=config.content_sort,
+            cache_seed=cache_seed,
         )
         (
             content_total_files,
@@ -332,6 +387,40 @@ class BuildCommand(BaseCommand):
                 ignore=shutil.ignore_patterns("*.html"),
             )
 
+    def _build_asset_manifest(
+        self,
+        paths: BuildPaths,
+        config: SiteConfig,
+        highlighter: SyntaxHighlighter | None,
+    ) -> AssetVersionManifest:
+        versions: dict[str, str] = {}
+
+        for asset_path in sorted(paths.templates_dir.rglob("*")):
+            if not asset_path.is_file() or asset_path.suffix == ".html":
+                continue
+            output_path = asset_path.relative_to(paths.templates_dir).as_posix()
+            versions[output_path] = _compute_asset_version(asset_path.read_bytes())
+
+        if highlighter:
+            versions["syntax.css"] = _compute_asset_version(
+                highlighter.get_stylesheet().encode("utf-8")
+            )
+
+        static_dir = paths.project_dir / config.static_dir
+        if static_dir.is_dir():
+            static_mode = StaticDirOutputMode(config.static_dir_output)
+            for asset_path in sorted(static_dir.rglob("*")):
+                if not asset_path.is_file():
+                    continue
+                rel_path = asset_path.relative_to(static_dir).as_posix()
+                if static_mode is StaticDirOutputMode.ROOT:
+                    output_path = rel_path
+                else:
+                    output_path = f"{static_mode.value}/{rel_path}"
+                versions[output_path] = _compute_asset_version(asset_path.read_bytes())
+
+        return AssetVersionManifest(versions=MappingProxyType(versions))
+
     def _iter_template_filenames(self, templates_dir: Path) -> list[str]:
         return sorted(
             str(path.relative_to(templates_dir).as_posix())
@@ -347,6 +436,7 @@ class BuildCommand(BaseCommand):
         collection: MarkdownCollection,
         cache: BuildCache,
         content_sort: str,
+        cache_seed: str,
     ) -> tuple[int, int, int]:
         total_files = 0
         built_files = 0
@@ -364,6 +454,7 @@ class BuildCommand(BaseCommand):
                 sorted_content=sorted_content,
                 tag_map=tag_map,
                 cache=cache,
+                cache_seed=cache_seed,
             )
             if result.cached:
                 cached_files += 1
@@ -476,13 +567,15 @@ class BuildCommand(BaseCommand):
         sorted_content: list[MarkdownContent],
         tag_map: TagMap,
         cache: BuildCache,
+        cache_seed: str,
     ) -> TemplateRenderResult:
         filepath = os.path.join(templates_dir, filename)
         with open(filepath) as f:
             template = f.read()
 
+        cache_content = self._template_cache_content(template, cache_seed)
         is_dynamic = cache.has_dynamic_constructs(template)
-        if not is_dynamic and not cache.needs_rebuild(filename, template):
+        if not is_dynamic and not cache.needs_rebuild(filename, cache_content):
             return TemplateRenderResult(built=False, cached=True)
 
         rendered = engine.render(
@@ -498,8 +591,13 @@ class BuildCommand(BaseCommand):
             f.write(rendered)
 
         if not is_dynamic:
-            cache.update(filename, template)
+            cache.update(filename, cache_content)
         return TemplateRenderResult(built=True, cached=False)
+
+    def _template_cache_content(self, template: str, cache_seed: str) -> str:
+        if cache_seed == "":
+            return template
+        return f"{template}\0{cache_seed}"
 
     def _sort_content(
         self, collection: MarkdownCollection, content_sort: str

--- a/pyssg/modules/html.py
+++ b/pyssg/modules/html.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from jinja2 import BaseLoader, Environment, Template
 
@@ -46,6 +46,11 @@ class ComponentMatch:
     end: int
     attrs: dict[str, str]
     children: str = field(default="")
+
+
+class AssetManifest(Protocol):
+    def asset_url(self, path: str) -> str:
+        pass
 
 
 def _build_line_offsets(html: str) -> list[int]:
@@ -247,11 +252,13 @@ class HtmlTemplateEngine:
         components_dir: Path | None = None,
         component_names: list[str] | None = None,
         config: SiteConfig | None = None,
+        asset_manifest: AssetManifest | None = None,
     ) -> None:
         self.templates_dir = templates_dir
         self.components_dir = components_dir
         self.component_names = component_names or []
         self.config = config
+        self.asset_manifest = asset_manifest
         self._component_set: set[str] = set(self.component_names)
         self._component_cache: dict[str, Template] = {}
 
@@ -276,6 +283,8 @@ class HtmlTemplateEngine:
         render_context: dict[str, Any] = {}
         if self.config:
             render_context["site"] = self.config
+        if self.asset_manifest is not None:
+            render_context["asset_url"] = self.asset_manifest.asset_url
         if context:
             render_context.update(context)
         jinja_template = _jinja_env.from_string(template)

--- a/tests/app/commands/test_build.py
+++ b/tests/app/commands/test_build.py
@@ -1,8 +1,10 @@
+import hashlib
 from pathlib import Path
 from types import MappingProxyType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from pyssg.commands.build import (
+    AssetVersionManifest,
     BuildCommand,
     BuildPaths,
     RenderSummary,
@@ -177,6 +179,25 @@ def test_copy_static_assets_returns_none_when_source_missing(tmp_path: Path) -> 
     output_path = _copy_static_assets(tmp_path / "missing-static", output_dir, "static")
 
     assert output_path is None
+
+
+def test_asset_version_manifest_appends_version_to_local_asset_urls() -> None:
+    manifest = AssetVersionManifest(
+        versions={
+            "static/site.css": "abc123",
+            "syntax.css": "def456",
+        }
+    )
+
+    assert manifest.asset_url("/static/site.css") == "/static/site.css?v=abc123"
+    assert manifest.asset_url("syntax.css") == "syntax.css?v=def456"
+    assert (
+        manifest.asset_url("/static/site.css?theme=light")
+        == "/static/site.css?theme=light&v=abc123"
+    )
+    assert manifest.asset_url("https://cdn.example.com/site.css") == (
+        "https://cdn.example.com/site.css"
+    )
 
 
 @patch(f"{TEST_PATH}.Path.cwd")
@@ -449,6 +470,69 @@ def test_copy_template_directories_skips_nested_html_page_templates(
     )
 
 
+def test_build_asset_manifest_versions_template_static_and_syntax_assets(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "project"
+    templates_dir = project_dir / "templates"
+    static_dir = project_dir / "static"
+    output_dir = project_dir / "output"
+    templates_assets_dir = templates_dir / "assets"
+    templates_assets_dir.mkdir(parents=True)
+    static_dir.mkdir(parents=True)
+    output_dir.mkdir(parents=True)
+    (templates_assets_dir / "app.css").write_text("body {}", encoding="utf-8")
+    (templates_dir / "index.html").write_text("<h1>Home</h1>", encoding="utf-8")
+    (static_dir / "site.css").write_text("html {}", encoding="utf-8")
+    paths = BuildPaths(
+        project_dir=project_dir,
+        templates_dir=templates_dir,
+        components_dir=project_dir / "components",
+        output_dir=output_dir,
+    )
+    highlighter = MagicMock()
+    highlighter.get_stylesheet.return_value = ".highlight {}"
+    command = SilentBuildCommand()
+
+    manifest = command._build_asset_manifest(paths, _default_config(), highlighter)
+
+    assert manifest.asset_url("/assets/app.css").startswith("/assets/app.css?v=")
+    assert manifest.asset_url("/static/site.css").startswith("/static/site.css?v=")
+    assert manifest.asset_url("syntax.css").startswith("syntax.css?v=")
+
+
+def test_build_asset_manifest_prefers_static_assets_for_colliding_output_paths(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "project"
+    templates_dir = project_dir / "templates"
+    static_dir = project_dir / "static"
+    output_dir = project_dir / "output"
+    templates_dir.mkdir(parents=True)
+    static_dir.mkdir(parents=True)
+    output_dir.mkdir(parents=True)
+    (templates_dir / "shared.css").write_text("template", encoding="utf-8")
+    (static_dir / "shared.css").write_text("static", encoding="utf-8")
+    paths = BuildPaths(
+        project_dir=project_dir,
+        templates_dir=templates_dir,
+        components_dir=project_dir / "components",
+        output_dir=output_dir,
+    )
+    command = SilentBuildCommand()
+
+    manifest = command._build_asset_manifest(
+        paths,
+        _default_config(static_dir_output="root"),
+        None,
+    )
+
+    assert manifest.versions["shared.css"] == hashlib.sha256(b"static").hexdigest()[:12]
+    assert manifest.asset_url("/shared.css") == (
+        f"/shared.css?v={manifest.versions['shared.css']}"
+    )
+
+
 def test_render_template_file_builds_static_template(tmp_path: Path) -> None:
     templates_dir = tmp_path / "templates"
     templates_dir.mkdir()
@@ -471,14 +555,17 @@ def test_render_template_file_builds_static_template(tmp_path: Path) -> None:
         sorted_content=[post],
         tag_map=MappingProxyType({"python": (post,)}),
         cache=cache,
+        cache_seed="static/site.css=abc123",
     )
 
     assert result == TemplateRenderResult(built=True, cached=False)
-    engine.render.assert_called_once_with(
-        "<h1>Template</h1>",
-        context={"content": (post,), "tags": MappingProxyType({"python": (post,)})},
+    render_context = engine.render.call_args.kwargs["context"]
+    assert render_context["content"] == (post,)
+    assert render_context["tags"] == MappingProxyType({"python": (post,)})
+    cache.update.assert_called_once_with(
+        "index.html",
+        "<h1>Template</h1>\0static/site.css=abc123",
     )
-    cache.update.assert_called_once_with("index.html", "<h1>Template</h1>")
     assert (output_dir / "index.html").read_text(
         encoding="utf-8"
     ) == "<h1>Rendered</h1>"
@@ -504,11 +591,16 @@ def test_render_template_file_skips_unchanged_static_template(tmp_path: Path) ->
         sorted_content=[],
         tag_map={},
         cache=cache,
+        cache_seed="static/site.css=abc123",
     )
 
     assert result == TemplateRenderResult(built=False, cached=True)
     engine.render.assert_not_called()
     cache.update.assert_not_called()
+    cache.needs_rebuild.assert_called_once_with(
+        "index.html",
+        "<h1>Template</h1>\0static/site.css=abc123",
+    )
     assert not (output_dir / "index.html").exists()
 
 
@@ -537,6 +629,7 @@ def test_render_template_file_does_not_update_cache_for_dynamic_templates(
         sorted_content=[],
         tag_map={},
         cache=cache,
+        cache_seed="static/site.css=abc123",
     )
 
     assert result == TemplateRenderResult(built=True, cached=False)
@@ -564,6 +657,7 @@ def test_render_template_file_dry_run_does_not_write_output(tmp_path: Path) -> N
         sorted_content=[],
         tag_map={},
         cache=cache,
+        cache_seed="static/site.css=abc123",
     )
 
     assert result == TemplateRenderResult(built=True, cached=False)
@@ -593,6 +687,7 @@ def test_render_template_files_counts_only_html_files(tmp_path: Path) -> None:
         collection=_make_collection(),
         cache=cache,
         content_sort="date_desc",
+        cache_seed="",
     )
 
     assert summary == (2, 2, 0)
@@ -622,6 +717,7 @@ def test_render_template_files_skips_render_only_template_files(tmp_path: Path) 
         collection=_make_collection(),
         cache=cache,
         content_sort="date_desc",
+        cache_seed="",
     )
 
     assert summary == (1, 1, 0)
@@ -655,6 +751,7 @@ def test_render_template_files_renders_nested_html_templates(tmp_path: Path) -> 
         collection=_make_collection(),
         cache=cache,
         content_sort="date_desc",
+        cache_seed="",
     )
 
     assert summary == (2, 2, 0)
@@ -774,6 +871,7 @@ def test_render_template_files_passes_immutable_sorted_content(tmp_path: Path) -
         collection=_make_collection(older, newer),
         cache=cache,
         content_sort="date_desc",
+        cache_seed="",
     )
 
     render_context = engine.render.call_args.kwargs["context"]
@@ -813,6 +911,7 @@ def test_render_template_files_passes_tags_mapping_to_templates(tmp_path: Path) 
         collection=_make_collection(older, newer),
         cache=cache,
         content_sort="date_desc",
+        cache_seed="",
     )
 
     render_context = engine.render.call_args.kwargs["context"]

--- a/tests/app/modules/test_html.py
+++ b/tests/app/modules/test_html.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
+from pyssg.commands.build import AssetVersionManifest
 from pyssg.modules.config import AuthorConfig, SiteConfig
 from pyssg.modules.html import HtmlTemplateEngine
 from pyssg.modules.markdown import MarkdownContent
@@ -230,6 +231,22 @@ class TestRenderTemplate:
         )
 
         assert result == "Hello wo..."
+
+    def test_asset_url_available_in_template_when_manifest_provided(self):
+        engine = HtmlTemplateEngine(
+            templates_dir=Path("/templates"),
+            components_dir=Path("/components"),
+            component_names=[],
+            asset_manifest=AssetVersionManifest(
+                versions={"static/site.css": "abc123", "syntax.css": "def456"}
+            ),
+        )
+
+        result = engine.render(
+            "{{ asset_url('/static/site.css') }} {{ asset_url('syntax.css') }}"
+        )
+
+        assert result == "/static/site.css?v=abc123 syntax.css?v=def456"
 
 
 class TestSiteConfigInTemplates:

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ wheels = [
 
 [[package]]
 name = "py-ssg"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Implement a cache-busting system for static assets by introducing the asset_url() template helper function. This feature allows templates to append build-time version query strings to asset URLs, ensuring browsers fetch the latest files instead of serving stale cached copies.

Key changes:

- Added asset_url() template global that takes local asset paths and appends a content-based version query string
- Implemented AssetVersionManifest to compute and manage SHA256-based versions for all assets
- Asset manifest includes template-directory assets, static directory assets, and generated syntax.css
- When manifests conflict (same output path from different sources), static directory assets take precedence
- Updated template cache to include asset manifest fingerprint as seed, ensuring templates rebuild when assets change
- Added comprehensive test coverage for asset versioning and manifest building
- Updated README documentation with usage examples and asset_url() reference

External URLs and CDN assets are passed through unchanged. The feature supports existing query parameters and appends the version parameter after any existing query string.