### PR TITLE
feat: Add tag page generation from frontmatter tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ theme_dark = "monokai"          # Pygments theme for dark mode
 enabled = false                 # Table of contents generation
 max_depth = 3                   # Max heading depth to include
 
+[py-ssg.tag_pages]
+template = ""                   # Render-only template used for each generated tag page
+output_dir = "tags"             # Output base path under output/
+
 [[py-ssg.authors]]
 name = "Your Name"
 email = "your@email.com"
@@ -330,6 +334,37 @@ Quirks:
 - Content-page outputs always follow the canonical route from `post.url`.
 - Content-page rendering is currently not template-cached; these pages rebuild every time.
 - If `template` points to a normal `.html` page template instead of `*.tmpl.html`, py-ssg warns because that template will also render as its own standalone page.
+
+### Tag Pages
+
+You can generate one page per tag from frontmatter tags by configuring a render-only template:
+
+```toml
+[py-ssg.tag_pages]
+template = "tags/list.tmpl.html"
+output_dir = "tags"
+```
+
+For tags like `python` and `release notes`, py-ssg renders:
+
+```text
+output/tags/python/index.html
+output/tags/release-notes/index.html
+```
+
+Each tag page receives:
+
+- `site`
+- `content`
+- `tags`
+- `tag`
+
+The `tag` object exposes:
+
+- `tag.name`
+- `tag.slug`
+- `tag.output_filename`
+- `tag.posts`
 
 ## Templates
 

--- a/pyssg/commands/build.py
+++ b/pyssg/commands/build.py
@@ -14,7 +14,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from pyssg.commands.base_command import BaseCommand
 from pyssg.modules.build_script import BuildContext, BuildScript
 from pyssg.modules.cache import BuildCache
-from pyssg.modules.config import SiteConfig
+from pyssg.modules.config import SiteConfig, TagPagesConfig
 from pyssg.modules.html import HtmlTemplateEngine
 from pyssg.modules.markdown import (
     MarkdownCollection,
@@ -25,6 +25,7 @@ from pyssg.modules.markdown import (
 )
 from pyssg.modules.rss import RssFeedGenerator
 from pyssg.modules.syntax import SyntaxHighlighter
+from pyssg.modules.template_helpers import slug
 
 
 def _discover_components(components_dir: Path) -> list[str]:
@@ -166,6 +167,14 @@ class RenderSummary:
 class TemplateRenderResult:
     built: bool
     cached: bool
+
+
+@dataclass(frozen=True)
+class TagPage:
+    name: str
+    slug: str
+    output_filename: str
+    posts: tuple[MarkdownContent, ...]
 
 
 type TagMap = Mapping[str, Sequence[MarkdownContent]]
@@ -350,6 +359,15 @@ class BuildCommand(BaseCommand):
             cache=cache,
             content_sort=config.content_sort,
         )
+        tag_total_files, tag_built_files, tag_cached_files = self._render_tag_pages(
+            templates_dir=paths.templates_dir,
+            output_dir=paths.output_dir,
+            engine=engine,
+            collection=collection,
+            cache=cache,
+            content_sort=config.content_sort,
+            tag_pages=config.tag_pages,
+        )
         if self._dry_run:
             if highlighter:
                 self._detail(
@@ -366,9 +384,9 @@ class BuildCommand(BaseCommand):
             self._copy_static_assets(paths=paths, config=config)
 
         return RenderSummary(
-            total_files=total_files + content_total_files,
-            built_files=built_files + content_built_files,
-            cached_files=cached_files + content_cached_files,
+            total_files=total_files + content_total_files + tag_total_files,
+            built_files=built_files + content_built_files + tag_built_files,
+            cached_files=cached_files + content_cached_files + tag_cached_files,
             component_names=component_names,
             rendering_time=time.perf_counter() - rendering_start,
         )
@@ -523,6 +541,62 @@ class BuildCommand(BaseCommand):
                 "only be used through frontmatter."
             )
 
+    def _build_tag_pages(self, tag_map: TagMap, output_dir: str) -> tuple[TagPage, ...]:
+        normalized_output_dir = output_dir.strip("/")
+        tag_pages: list[TagPage] = []
+        for tag_name, posts in tag_map.items():
+            tag_slug = slug(tag_name)
+            tag_output_filename = f"{tag_slug}/index.html"
+            if normalized_output_dir:
+                tag_output_filename = f"{normalized_output_dir}/{tag_output_filename}"
+            tag_pages.append(
+                TagPage(
+                    name=tag_name,
+                    slug=tag_slug,
+                    output_filename=tag_output_filename,
+                    posts=tuple(posts),
+                )
+            )
+        return tuple(tag_pages)
+
+    def _render_tag_pages(
+        self,
+        templates_dir: Path,
+        output_dir: Path,
+        engine: HtmlTemplateEngine,
+        collection: MarkdownCollection,
+        cache: BuildCache,
+        content_sort: str,
+        tag_pages: TagPagesConfig,
+    ) -> tuple[int, int, int]:
+        del cache
+        if tag_pages.template == "":
+            return 0, 0, 0
+
+        total_files = 0
+        built_files = 0
+        cached_files = 0
+        sorted_content = self._sort_content(collection, content_sort)
+        tag_map = self._build_tag_map(sorted_content)
+
+        for tag_page in self._build_tag_pages(tag_map, tag_pages.output_dir):
+            total_files += 1
+            result = self._render_tag_page(
+                template_name=tag_pages.template,
+                templates_dir=templates_dir,
+                output_dir=output_dir,
+                engine=engine,
+                sorted_content=sorted_content,
+                tag_map=tag_map,
+                tag_page=tag_page,
+            )
+            if result.cached:
+                cached_files += 1
+            if result.built:
+                built_files += 1
+
+        return total_files, built_files, cached_files
+
     def _render_content_page(
         self,
         template_name: str,
@@ -592,6 +666,38 @@ class BuildCommand(BaseCommand):
 
         if not is_dynamic:
             cache.update(filename, cache_content)
+        return TemplateRenderResult(built=True, cached=False)
+
+    def _render_tag_page(
+        self,
+        template_name: str,
+        templates_dir: Path,
+        output_dir: Path,
+        engine: HtmlTemplateEngine,
+        sorted_content: list[MarkdownContent],
+        tag_map: TagMap,
+        tag_page: TagPage,
+    ) -> TemplateRenderResult:
+        filepath = os.path.join(templates_dir, template_name)
+        with open(filepath) as f:
+            template = f.read()
+
+        rendered = engine.render(
+            template,
+            context={
+                "content": tuple(sorted_content),
+                "tags": tag_map,
+                "tag": tag_page,
+            },
+        )
+        if self._dry_run:
+            self._detail(f"Dry run: would render {tag_page.output_filename}")
+            return TemplateRenderResult(built=True, cached=False)
+        output_path = os.path.join(output_dir, tag_page.output_filename)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w") as f:
+            f.write(rendered)
+
         return TemplateRenderResult(built=True, cached=False)
 
     def _template_cache_content(self, template: str, cache_seed: str) -> str:

--- a/pyssg/commands/build.py
+++ b/pyssg/commands/build.py
@@ -544,8 +544,21 @@ class BuildCommand(BaseCommand):
     def _build_tag_pages(self, tag_map: TagMap, output_dir: str) -> tuple[TagPage, ...]:
         normalized_output_dir = output_dir.strip("/")
         tag_pages: list[TagPage] = []
+        seen_slugs: set[str] = set()
         for tag_name, posts in tag_map.items():
             tag_slug = slug(tag_name)
+            if not tag_slug:
+                self._warning(
+                    f"Tag {tag_name!r} produces an empty slug and will be skipped."
+                )
+                continue
+            if tag_slug in seen_slugs:
+                self._warning(
+                    f"Tag {tag_name!r} produces slug {tag_slug!r} which collides "
+                    "with an existing tag and will be skipped."
+                )
+                continue
+            seen_slugs.add(tag_slug)
             tag_output_filename = f"{tag_slug}/index.html"
             if normalized_output_dir:
                 tag_output_filename = f"{normalized_output_dir}/{tag_output_filename}"
@@ -573,17 +586,28 @@ class BuildCommand(BaseCommand):
         if tag_pages.template == "":
             return 0, 0, 0
 
+        if not _is_render_only_template(tag_pages.template):
+            base = tag_pages.template.removesuffix(".html")
+            self._warning(
+                f"Tag pages template {tag_pages.template} is not render-only and will "
+                "also be rendered as a standalone page. Rename it to "
+                f"{base}.tmpl.html if it should only be used for tag pages."
+            )
+
         total_files = 0
         built_files = 0
         cached_files = 0
         sorted_content = self._sort_content(collection, content_sort)
         tag_map = self._build_tag_map(sorted_content)
 
+        filepath = os.path.join(templates_dir, tag_pages.template)
+        with open(filepath) as f:
+            template = f.read()
+
         for tag_page in self._build_tag_pages(tag_map, tag_pages.output_dir):
             total_files += 1
             result = self._render_tag_page(
-                template_name=tag_pages.template,
-                templates_dir=templates_dir,
+                template=template,
                 output_dir=output_dir,
                 engine=engine,
                 sorted_content=sorted_content,
@@ -670,18 +694,13 @@ class BuildCommand(BaseCommand):
 
     def _render_tag_page(
         self,
-        template_name: str,
-        templates_dir: Path,
+        template: str,
         output_dir: Path,
         engine: HtmlTemplateEngine,
         sorted_content: list[MarkdownContent],
         tag_map: TagMap,
         tag_page: TagPage,
     ) -> TemplateRenderResult:
-        filepath = os.path.join(templates_dir, template_name)
-        with open(filepath) as f:
-            template = f.read()
-
         rendered = engine.render(
             template,
             context={

--- a/pyssg/modules/config.py
+++ b/pyssg/modules/config.py
@@ -102,6 +102,19 @@ class ServerConfig:
 
 
 @dataclass
+class TagPagesConfig:
+    template: str = ""
+    output_dir: str = "tags"
+
+    @classmethod
+    def from_dict(cls, data: dict) -> TagPagesConfig:
+        return cls(
+            template=str(data.get("template", "")),
+            output_dir=str(data.get("output_dir", "tags")),
+        )
+
+
+@dataclass
 class SiteConfig:
     name: str = ""
     url: str = ""
@@ -116,6 +129,7 @@ class SiteConfig:
     syntax: SyntaxConfig = field(default_factory=SyntaxConfig)
     server: ServerConfig = field(default_factory=ServerConfig)
     toc: TocConfig = field(default_factory=TocConfig)
+    tag_pages: TagPagesConfig = field(default_factory=TagPagesConfig)
 
     @classmethod
     def load(cls, project_dir: Path) -> SiteConfig:
@@ -133,6 +147,7 @@ class SiteConfig:
         syntax = SyntaxConfig.from_dict(data.get("syntax", {}))
         server = ServerConfig.from_dict(data.get("server", {}))
         toc = TocConfig.from_dict(data.get("toc", {}))
+        tag_pages = TagPagesConfig.from_dict(data.get("tag_pages", {}))
         static_dir_output = _validate_static_dir_output(
             str(data.get("static_dir_output", "static"))
         )
@@ -153,4 +168,5 @@ class SiteConfig:
             syntax=syntax,
             server=server,
             toc=toc,
+            tag_pages=tag_pages,
         )

--- a/pyssg/templates/py-ssg.toml
+++ b/pyssg/templates/py-ssg.toml
@@ -20,6 +20,10 @@ theme_dark = "monokai"
 enabled = false
 max_depth = 3
 
+[py-ssg.tag_pages]
+template = ""
+output_dir = "tags"
+
 [[py-ssg.authors]]
 name = "Your Name"
 email = "your@email.com"

--- a/tests/app/commands/test_build.py
+++ b/tests/app/commands/test_build.py
@@ -381,6 +381,40 @@ def test_build_tag_pages_uses_slugged_output_paths() -> None:
     )
 
 
+@patch.object(BuildCommand, "_warning")
+def test_build_tag_pages_warns_and_skips_tags_with_empty_slug(
+    mock_warning: MagicMock,
+) -> None:
+    command = SilentBuildCommand()
+    post = MarkdownContent(filename="post.md", html="", tags=["!!!"])
+
+    tag_pages = command._build_tag_pages(
+        MappingProxyType({"!!!": (post,)}),
+        output_dir="tags",
+    )
+
+    assert tag_pages == ()
+    mock_warning.assert_called_once()
+
+
+@patch.object(BuildCommand, "_warning")
+def test_build_tag_pages_warns_and_skips_duplicate_slugs(
+    mock_warning: MagicMock,
+) -> None:
+    command = SilentBuildCommand()
+    c_post = MarkdownContent(filename="c.md", html="", tags=["C"])
+    cpp_post = MarkdownContent(filename="cpp.md", html="", tags=["C++"])
+
+    tag_pages = command._build_tag_pages(
+        MappingProxyType({"C": (c_post,), "C++": (cpp_post,)}),
+        output_dir="tags",
+    )
+
+    assert len(tag_pages) == 1
+    assert tag_pages[0].name == "C"
+    mock_warning.assert_called_once()
+
+
 @patch.object(BuildCommand, "_info")
 @patch(f"{TEST_PATH}.MarkdownParser")
 @patch(f"{TEST_PATH}.os.cpu_count")
@@ -909,6 +943,78 @@ def test_render_tag_pages_generates_a_page_per_tag(tmp_path: Path) -> None:
     assert (output_dir / "tags" / "python" / "index.html").read_text(
         encoding="utf-8"
     ) == "<h1>python</h1><article>New Post</article>"
+
+
+def test_render_tag_pages_reads_template_file_once_for_multiple_tags(
+    tmp_path: Path,
+) -> None:
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    template_file = templates_dir / "tags.tmpl.html"
+    template_file.write_text("<h1>{{ tag.name }}</h1>", encoding="utf-8")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    post1 = MarkdownContent(filename="p1.md", html="", tags=["python"])
+    post2 = MarkdownContent(filename="p2.md", html="", tags=["rust"])
+    engine = MagicMock()
+    engine.render.return_value = "<h1>tag</h1>"
+    cache = MagicMock()
+    command = SilentBuildCommand()
+
+    original_open = open
+    opens_of_template: list[str] = []
+
+    def tracking_open(file, *args, **kwargs):
+        if str(template_file) == str(file):
+            opens_of_template.append(str(file))
+        return original_open(file, *args, **kwargs)
+
+    with patch("builtins.open", side_effect=tracking_open):
+        command._render_tag_pages(
+            templates_dir=templates_dir,
+            output_dir=output_dir,
+            engine=engine,
+            collection=_make_collection(post1, post2),
+            cache=cache,
+            content_sort="date_desc",
+            tag_pages=TagPagesConfig(template="tags.tmpl.html"),
+        )
+
+    assert len(opens_of_template) == 1
+
+
+@patch.object(BuildCommand, "_warning")
+def test_render_tag_pages_warns_when_template_is_not_render_only(
+    mock_warning: MagicMock, tmp_path: Path
+) -> None:
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "tags.html").write_text(
+        "<h1>{{ tag.name }}</h1>", encoding="utf-8"
+    )
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    post = MarkdownContent(filename="p.md", html="", tags=["python"])
+    engine = MagicMock()
+    engine.render.return_value = "<h1>python</h1>"
+    cache = MagicMock()
+    command = SilentBuildCommand()
+
+    command._render_tag_pages(
+        templates_dir=templates_dir,
+        output_dir=output_dir,
+        engine=engine,
+        collection=_make_collection(post),
+        cache=cache,
+        content_sort="date_desc",
+        tag_pages=TagPagesConfig(template="tags.html"),
+    )
+
+    mock_warning.assert_called_once_with(
+        "Tag pages template tags.html is not render-only and will also be "
+        "rendered as a standalone page. Rename it to tags.tmpl.html if it "
+        "should only be used for tag pages."
+    )
 
 
 @patch.object(BuildCommand, "_warning")

--- a/tests/app/commands/test_build.py
+++ b/tests/app/commands/test_build.py
@@ -8,11 +8,18 @@ from pyssg.commands.build import (
     BuildCommand,
     BuildPaths,
     RenderSummary,
+    TagPage,
     TemplateRenderResult,
     _copy_static_assets,
     _discover_components,
 )
-from pyssg.modules.config import FeedConfig, SiteConfig, SyntaxConfig, TocConfig
+from pyssg.modules.config import (
+    FeedConfig,
+    SiteConfig,
+    SyntaxConfig,
+    TagPagesConfig,
+    TocConfig,
+)
 from pyssg.modules.markdown import MarkdownCollection, MarkdownContent
 
 TEST_PATH = "pyssg.commands.build"
@@ -29,9 +36,11 @@ def _default_config(
     cache: bool = True,
     syntax: SyntaxConfig | None = None,
     toc: TocConfig | None = None,
+    tag_pages: TagPagesConfig | None = None,
 ) -> SiteConfig:
     syntax = syntax or SyntaxConfig(enabled=False)
     toc = toc or TocConfig(enabled=False)
+    tag_pages = tag_pages or TagPagesConfig()
     return SiteConfig(
         name=name,
         url=url,
@@ -42,6 +51,7 @@ def _default_config(
         cache=cache,
         syntax=syntax,
         toc=toc,
+        tag_pages=tag_pages,
     )
 
 
@@ -336,6 +346,39 @@ def test_build_tag_map_groups_posts_by_tag_in_sorted_order() -> None:
         "release": (newest,),
         "notes": (undated,),
     }
+
+
+def test_build_tag_pages_uses_slugged_output_paths() -> None:
+    command = SilentBuildCommand()
+    python_post = MarkdownContent(filename="python.md", html="", tags=["Python Tips"])
+    release_post = MarkdownContent(
+        filename="release.md", html="", tags=["Release Notes"]
+    )
+
+    tag_pages = command._build_tag_pages(
+        MappingProxyType(
+            {
+                "Python Tips": (python_post,),
+                "Release Notes": (release_post,),
+            }
+        ),
+        output_dir="tags",
+    )
+
+    assert tag_pages == (
+        TagPage(
+            name="Python Tips",
+            slug="python-tips",
+            output_filename="tags/python-tips/index.html",
+            posts=(python_post,),
+        ),
+        TagPage(
+            name="Release Notes",
+            slug="release-notes",
+            output_filename="tags/release-notes/index.html",
+            posts=(release_post,),
+        ),
+    )
 
 
 @patch.object(BuildCommand, "_info")
@@ -807,6 +850,65 @@ def test_render_content_pages_generates_pages_from_content_templates(
     assert (output_dir / "blog" / "hello-world" / "index.html").read_text(
         encoding="utf-8"
     ) == "<article>Hello World</article>"
+
+
+def test_render_tag_pages_generates_a_page_per_tag(tmp_path: Path) -> None:
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    tags_dir = templates_dir / "tags"
+    tags_dir.mkdir()
+    (tags_dir / "list.tmpl.html").write_text(
+        "<h1>{{ tag.name }}</h1>{% for post in tag.posts %}<article>{{ post.title }}</article>{% endfor %}",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    newer = MarkdownContent(
+        filename="new.md",
+        html="",
+        title="New Post",
+        timestamp="2025-01-01",
+        tags=["python"],
+    )
+    older = MarkdownContent(
+        filename="old.md",
+        html="",
+        title="Old Post",
+        timestamp="2024-01-01",
+        tags=["python"],
+    )
+    engine = MagicMock()
+    engine.render.return_value = "<h1>python</h1><article>New Post</article>"
+    cache = MagicMock()
+    command = SilentBuildCommand()
+
+    summary = command._render_tag_pages(
+        templates_dir=templates_dir,
+        output_dir=output_dir,
+        engine=engine,
+        collection=_make_collection(older, newer),
+        cache=cache,
+        content_sort="date_desc",
+        tag_pages=TagPagesConfig(template="tags/list.tmpl.html"),
+    )
+
+    assert summary == (1, 1, 0)
+    engine.render.assert_called_once_with(
+        "<h1>{{ tag.name }}</h1>{% for post in tag.posts %}<article>{{ post.title }}</article>{% endfor %}",
+        context={
+            "content": (newer, older),
+            "tags": MappingProxyType({"python": (newer, older)}),
+            "tag": TagPage(
+                name="python",
+                slug="python",
+                output_filename="tags/python/index.html",
+                posts=(newer, older),
+            ),
+        },
+    )
+    assert (output_dir / "tags" / "python" / "index.html").read_text(
+        encoding="utf-8"
+    ) == "<h1>python</h1><article>New Post</article>"
 
 
 @patch.object(BuildCommand, "_warning")

--- a/tests/app/modules/test_config.py
+++ b/tests/app/modules/test_config.py
@@ -9,6 +9,7 @@ from pyssg.modules.config import (
     ServerConfig,
     SiteConfig,
     SyntaxConfig,
+    TagPagesConfig,
     TocConfig,
 )
 
@@ -100,6 +101,28 @@ class TestServerConfig:
         assert config.port == 8000
 
 
+class TestTagPagesConfig:
+    def test_default_values(self):
+        config = TagPagesConfig()
+
+        assert config.template == ""
+        assert config.output_dir == "tags"
+
+    def test_from_dict(self):
+        config = TagPagesConfig.from_dict(
+            {"template": "tags/list.tmpl.html", "output_dir": "topics"}
+        )
+
+        assert config.template == "tags/list.tmpl.html"
+        assert config.output_dir == "topics"
+
+    def test_from_dict_defaults(self):
+        config = TagPagesConfig.from_dict({})
+
+        assert config.template == ""
+        assert config.output_dir == "tags"
+
+
 class TestSiteConfig:
     def test_default_values(self):
         config = SiteConfig()
@@ -116,6 +139,7 @@ class TestSiteConfig:
         assert config.cache is True
         assert config.syntax == SyntaxConfig()
         assert config.server == ServerConfig()
+        assert config.tag_pages == TagPagesConfig()
 
     def test_from_dict_full(self):
         data = {
@@ -129,6 +153,10 @@ class TestSiteConfig:
             "cache": False,
             "authors": [{"name": "Jane", "email": "jane@example.com"}],
             "feeds": [{"title": "Feed", "output": "feed.xml"}],
+            "tag_pages": {
+                "template": "tags/list.tmpl.html",
+                "output_dir": "topics",
+            },
         }
 
         config = SiteConfig.from_dict(data)
@@ -146,6 +174,10 @@ class TestSiteConfig:
         assert config.authors[0].email == "jane@example.com"
         assert len(config.feeds) == 1
         assert config.feeds[0].title == "Feed"
+        assert config.tag_pages == TagPagesConfig(
+            template="tags/list.tmpl.html",
+            output_dir="topics",
+        )
 
     def test_from_dict_defaults(self):
         config = SiteConfig.from_dict({})
@@ -162,6 +194,7 @@ class TestSiteConfig:
         assert config.cache is True
         assert config.syntax == SyntaxConfig()
         assert config.server == ServerConfig()
+        assert config.tag_pages == TagPagesConfig()
 
     def test_from_dict_raises_for_invalid_static_dir_output(self):
         with pytest.raises(
@@ -246,6 +279,26 @@ class TestSiteConfig:
         assert len(config.feeds) == 2
         assert config.feeds[0].title == "All"
         assert config.feeds[1].tags == ["tech"]
+
+    def test_from_dict_tag_pages_section(self):
+        config = SiteConfig.from_dict(
+            {
+                "tag_pages": {
+                    "template": "tags/list.tmpl.html",
+                    "output_dir": "topics",
+                }
+            }
+        )
+
+        assert config.tag_pages == TagPagesConfig(
+            template="tags/list.tmpl.html",
+            output_dir="topics",
+        )
+
+    def test_from_dict_tag_pages_defaults_when_missing(self):
+        config = SiteConfig.from_dict({})
+
+        assert config.tag_pages == TagPagesConfig()
 
 
 class TestSiteConfigLoad:

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ wheels = [
 
 [[package]]
 name = "py-ssg"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
This change adds support for generating one page per tag extracted from article frontmatter. Users can now configure a render-only template to create dedicated tag listing pages automatically.

Key additions:

- New TagPagesConfig section in py-ssg.toml with template and output_dir settings
- TagPage dataclass representing a single generated tag page with name, slug, output filename, and associated posts
- _build_tag_pages method to construct tag page objects from the tag map
- _render_tag_pages method to generate all tag pages using the configured template
- Template context includes site, content, tags map, and current tag object
- Full documentation in README with configuration example and template variables
- Comprehensive test coverage for tag page generation and rendering

Tag pages are generated at output_dir/tag-slug/index.html, with tag names automatically slugified (e.g. "Python Tips" becomes "python-tips"). The feature is disabled by default when template is empty.

Version bumped to 0.2.4.